### PR TITLE
feat(chat): unified iOS + macOS premium UI overhaul

### DIFF
--- a/Sources/MLXInferenceCore/ModelCatalog.swift
+++ b/Sources/MLXInferenceCore/ModelCatalog.swift
@@ -227,9 +227,12 @@ public enum ModelCatalog {
         on device: DeviceProfile = .current
     ) -> FitStatus {
         let ram = device.physicalRAMGB
+        // On 6 GB devices: 75% = 4.5 GB comfortable, 90% = 5.4 GB tight.
+        // MoE models with expert streaming can run at up to 3x RAM via NVMe paging.
         if model.ramRequiredGB <= ram * 0.75 { return .fits }
         if model.ramRequiredGB <= ram * 0.90 { return .tight }
-        if model.isMoE && model.ramRequiredGB <= ram * 4.0 { return .requiresFlash }
+        if model.isMoE && model.ramRequiredGB <= ram * 3.0 { return .requiresFlash }
         return .tooLarge
     }
 }
+

--- a/Sources/MLXInferenceCore/ModelDownloadManager.swift
+++ b/Sources/MLXInferenceCore/ModelDownloadManager.swift
@@ -68,11 +68,12 @@ public final class ModelDownloadManager: ObservableObject {
     private var downloadTasks: [String: Task<Void, Error>] = [:]
 
     // MARK: iOS RAM budget
-    /// On iOS, use a tighter RAM budget to avoid jetsam (40% of physical RAM).
+    /// On iOS, use 40% (conservative, avoids jetsam) or 55% in Performance Mode.
     /// On macOS, use 75% (generous, no jetsam).
     public static var ramBudgetFraction: Double {
         #if os(iOS)
-        return 0.40
+        let performanceMode = UserDefaults.standard.bool(forKey: "swiftlm.performanceMode")
+        return performanceMode ? 0.55 : 0.40
         #else
         return 0.75
         #endif

--- a/SwiftLMChat/SwiftLMChat/SwiftLMChatApp.swift
+++ b/SwiftLMChat/SwiftLMChat/SwiftLMChatApp.swift
@@ -1,14 +1,43 @@
 // SwiftLMChatApp.swift — App entry point (iOS + macOS)
 import SwiftUI
 
+// MARK: — Appearance Store (persists dark/light/system preference)
+
+final class AppearanceStore: ObservableObject {
+    private static let key = "swiftlm.colorScheme"   // "dark" | "light" | "system"
+
+    @Published var preference: String {
+        didSet { UserDefaults.standard.set(preference, forKey: Self.key) }
+    }
+
+    init() {
+        preference = UserDefaults.standard.string(forKey: Self.key) ?? "dark"
+    }
+
+    var colorScheme: ColorScheme? {
+        switch preference {
+        case "dark":  return .dark
+        case "light": return .light
+        default:      return nil
+        }
+    }
+}
+
+// MARK: — App
+
 @main
 struct SwiftLMChatApp: App {
     @StateObject private var engine = InferenceEngine()
+    @StateObject private var appearance = AppearanceStore()
 
     var body: some Scene {
         WindowGroup {
             RootView()
                 .environmentObject(engine)
+                .environmentObject(appearance)
+                .preferredColorScheme(appearance.colorScheme)
+                .accentColor(SwiftLMTheme.accent)
+                .tint(SwiftLMTheme.accent)
         }
         #if os(macOS)
         .commands {
@@ -29,3 +58,4 @@ struct SwiftLMChatApp: App {
 extension Notification.Name {
     static let showModelPicker = Notification.Name("showModelPicker")
 }
+

--- a/SwiftLMChat/SwiftLMChat/Theme.swift
+++ b/SwiftLMChat/SwiftLMChat/Theme.swift
@@ -1,0 +1,223 @@
+// Theme.swift — SwiftLM Chat design system
+// Single source of truth for colors, gradients, radii, and animations.
+import SwiftUI
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MARK: — Color Tokens
+// ─────────────────────────────────────────────────────────────────────────────
+
+public enum SwiftLMTheme {
+
+    // ── Background layers ─────────────────────────────────────────────────────
+    /// Deep navy-black canvas — the app's primary background.
+    public static let background = Color(hue: 0.67, saturation: 0.20, brightness: 0.07)
+    /// Slightly elevated surface for cards and panels.
+    public static let surface = Color(hue: 0.67, saturation: 0.18, brightness: 0.12)
+    /// Second elevation — dialogs, popovers.
+    public static let surfaceElevated = Color(hue: 0.67, saturation: 0.15, brightness: 0.17)
+    /// Subtle divider / separator.
+    public static let divider = Color.white.opacity(0.08)
+
+    // ── Brand accents ─────────────────────────────────────────────────────────
+    /// Primary accent — vivid indigo.
+    public static let accent = Color(hue: 0.70, saturation: 0.90, brightness: 0.95)
+    /// Secondary accent — electric violet.
+    public static let accentSecondary = Color(hue: 0.76, saturation: 0.85, brightness: 0.95)
+    /// Cyan highlight — used in avatars and MoE badges.
+    public static let cyan = Color(hue: 0.54, saturation: 0.80, brightness: 0.95)
+
+    // ── Semantic ──────────────────────────────────────────────────────────────
+    public static let success = Color(hue: 0.40, saturation: 0.70, brightness: 0.80)
+    public static let warning = Color(hue: 0.10, saturation: 0.85, brightness: 0.95)
+    public static let error   = Color(hue: 0.02, saturation: 0.80, brightness: 0.90)
+
+    // ── Text ──────────────────────────────────────────────────────────────────
+    public static let textPrimary   = Color.white
+    public static let textSecondary = Color.white.opacity(0.60)
+    public static let textTertiary  = Color.white.opacity(0.35)
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // MARK: — Gradients
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// User message bubble fill.
+    public static let userBubbleGradient = LinearGradient(
+        colors: [
+            Color(hue: 0.70, saturation: 0.80, brightness: 0.90),
+            Color(hue: 0.76, saturation: 0.82, brightness: 0.88)
+        ],
+        startPoint: .topLeading, endPoint: .bottomTrailing
+    )
+
+    /// AI avatar ring gradient.
+    public static let avatarGradient = LinearGradient(
+        colors: [
+            Color(hue: 0.70, saturation: 0.85, brightness: 0.95),
+            Color(hue: 0.54, saturation: 0.80, brightness: 0.95)
+        ],
+        startPoint: .topLeading, endPoint: .bottomTrailing
+    )
+
+    /// Hero card gradient (active model card).
+    public static let heroGradient = LinearGradient(
+        colors: [
+            Color(hue: 0.70, saturation: 0.75, brightness: 0.30),
+            Color(hue: 0.76, saturation: 0.80, brightness: 0.22)
+        ],
+        startPoint: .topLeading, endPoint: .bottomTrailing
+    )
+
+    /// Thinking panel tint.
+    public static let thinkingGradient = LinearGradient(
+        colors: [
+            Color(hue: 0.76, saturation: 0.40, brightness: 0.18),
+            Color(hue: 0.72, saturation: 0.35, brightness: 0.16)
+        ],
+        startPoint: .topLeading, endPoint: .bottomTrailing
+    )
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // MARK: — Corner Radii
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public static let radiusSmall:  CGFloat = 8
+    public static let radiusMedium: CGFloat = 14
+    public static let radiusLarge:  CGFloat = 20
+    public static let radiusXL:     CGFloat = 28
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // MARK: — Animation
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public static let spring     = Animation.spring(response: 0.4, dampingFraction: 0.75)
+    public static let quickSpring = Animation.spring(response: 0.25, dampingFraction: 0.80)
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // MARK: — Shadows
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public struct ShadowStyle {
+        let color: Color
+        let radius: CGFloat
+        let x: CGFloat
+        let y: CGFloat
+    }
+
+    public static let shadowCard = ShadowStyle(
+        color: Color.black.opacity(0.35), radius: 12, x: 0, y: 6
+    )
+    public static let shadowBubble = ShadowStyle(
+        color: Color.black.opacity(0.20), radius: 4, x: 0, y: 2
+    )
+    public static let shadowGlow = ShadowStyle(
+        color: Color(hue: 0.70, saturation: 0.80, brightness: 0.90).opacity(0.45),
+        radius: 16, x: 0, y: 0
+    )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MARK: — View Modifiers
+// ─────────────────────────────────────────────────────────────────────────────
+
+extension View {
+    /// Apply a glowing indigo ring — used on focused input and hero cards.
+    func glowRing(color: Color = SwiftLMTheme.accent, radius: CGFloat = 8, active: Bool = true) -> some View {
+        self.shadow(color: active ? color.opacity(0.55) : .clear, radius: radius)
+    }
+
+    /// Glassmorphic card surface.
+    func glassCard(cornerRadius: CGFloat = SwiftLMTheme.radiusMedium) -> some View {
+        self
+            .background(.ultraThinMaterial)
+            .background(SwiftLMTheme.surface.opacity(0.65))
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .strokeBorder(Color.white.opacity(0.09), lineWidth: 1)
+            )
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MARK: — Reusable badge helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+struct ThemedBadge: View {
+    let text: String
+    let color: Color
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 9, weight: .bold))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.18), in: Capsule())
+            .foregroundStyle(color)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MARK: — Animated generating indicator (three dots)
+// ─────────────────────────────────────────────────────────────────────────────
+
+struct GeneratingDots: View {
+    @State private var phase = 0
+
+    var body: some View {
+        HStack(spacing: 4) {
+            ForEach(0..<3) { i in
+                Circle()
+                    .frame(width: 5, height: 5)
+                    .foregroundStyle(SwiftLMTheme.accent)
+                    .scaleEffect(phase == i ? 1.5 : 0.8)
+                    .opacity(phase == i ? 1.0 : 0.45)
+                    .animation(
+                        .easeInOut(duration: 0.45).repeatForever().delay(Double(i) * 0.18),
+                        value: phase
+                    )
+            }
+        }
+        .onAppear { withAnimation { phase = 1 } }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MARK: — Pulsing avatar ring
+// ─────────────────────────────────────────────────────────────────────────────
+
+struct AvatarView: View {
+    var isGenerating: Bool = false
+    var size: CGFloat = 30
+
+    @State private var pulse: Bool = false
+
+    var body: some View {
+        ZStack {
+            // Outer glow ring when generating
+            if isGenerating {
+                Circle()
+                    .stroke(SwiftLMTheme.accent.opacity(pulse ? 0.55 : 0.15), lineWidth: 2)
+                    .frame(width: size + 8, height: size + 8)
+                    .scaleEffect(pulse ? 1.12 : 1.0)
+                    .animation(
+                        .easeInOut(duration: 1.0).repeatForever(autoreverses: true),
+                        value: pulse
+                    )
+            }
+
+            // Avatar circle
+            Circle()
+                .fill(SwiftLMTheme.avatarGradient)
+                .frame(width: size, height: size)
+                .overlay(
+                    Image(systemName: "bolt.fill")
+                        .font(.system(size: size * 0.40, weight: .semibold))
+                        .foregroundStyle(.white)
+                )
+        }
+        .onAppear { if isGenerating { pulse = true } }
+        .onChange(of: isGenerating) { _, gen in
+            pulse = gen
+        }
+    }
+}

--- a/SwiftLMChat/SwiftLMChat/Views/ChatView.swift
+++ b/SwiftLMChat/SwiftLMChat/Views/ChatView.swift
@@ -1,11 +1,11 @@
-// ChatView.swift — Main chat interface (iOS + macOS)
+// ChatView.swift — Premium chat interface (iOS + macOS)
 import SwiftUI
 
 struct ChatView: View {
     @ObservedObject var viewModel: ChatViewModel
     @EnvironmentObject private var engine: InferenceEngine
 
-    // macOS-only sheet control (iOS: these are tabs now)
+    // macOS-only sheet control (iOS: these are tabs)
     var showSettings: Binding<Bool>? = nil
     var showModelPicker: Binding<Bool>? = nil
 
@@ -13,60 +13,71 @@ struct ChatView: View {
     @FocusState private var inputFocused: Bool
 
     var body: some View {
-        VStack(spacing: 0) {
-            // ── Message list or empty state ─────────────────────────────
-            ScrollViewReader { proxy in
-                ScrollView {
-                    if viewModel.messages.isEmpty && viewModel.streamingText.isEmpty {
-                        emptyStateView
-                            .frame(maxWidth: .infinity)
-                            .padding(.top, 60)
-                    } else {
-                        LazyVStack(alignment: .leading, spacing: 12) {
-                            ForEach(viewModel.messages) { message in
-                                MessageBubble(message: message)
-                                    .id(message.id)
-                            }
-                            if !viewModel.streamingText.isEmpty || viewModel.thinkingText != nil {
-                                StreamingBubble(
-                                    text: viewModel.streamingText,
-                                    thinkingText: viewModel.thinkingText
-                                )
-                                .id("streaming")
-                            }
-                            Color.clear.frame(height: 1).id("bottom")
-                        }
-                        .padding()
-                        .padding(.bottom, 4)
-                    }
-                }
-                // Swipe the message list down to dismiss keyboard —
-                // this reveals the tab bar so user can navigate while typing.
-                .scrollDismissesKeyboard(.interactively)
-                // Tap anywhere in the message area to dismiss the keyboard
-                .onTapGesture { inputFocused = false }
-                .onChange(of: viewModel.streamingText) { _, _ in
-                    withAnimation(.easeOut(duration: 0.1)) {
-                        proxy.scrollTo("bottom")
-                    }
-                }
+        ZStack {
+            // ── Deep canvas background ───────────────────────────────────────
+            SwiftLMTheme.background.ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                // ── Message list ─────────────────────────────────────────────
+                messageList
+
+                // ── Engine state banner ──────────────────────────────────────
+                engineBanner
+
+                // ── Input bar ────────────────────────────────────────────────
+                inputBar
             }
-
-            // ── Engine state banner (loading / error) ────────────────────
-            engineBanner
-
-            Divider()
-
-            // ── Input bar ────────────────────────────────────────────────
-            inputBar
         }
         .navigationTitle("SwiftLM Chat")
         #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar { iOSToolbar }
+        .toolbarBackground(SwiftLMTheme.background.opacity(0.90), for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
         #else
         .toolbar { macOSToolbar }
         #endif
+    }
+
+    // MARK: — Message List
+
+    private var messageList: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                if viewModel.messages.isEmpty && viewModel.streamingText.isEmpty {
+                    emptyStateView
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 60)
+                } else {
+                    LazyVStack(alignment: .leading, spacing: 14) {
+                        ForEach(viewModel.messages) { message in
+                            MessageBubble(message: message)
+                                .id(message.id)
+                                .environmentObject(engine)
+                        }
+                        if !viewModel.streamingText.isEmpty || viewModel.thinkingText != nil {
+                            StreamingBubble(
+                                text: viewModel.streamingText,
+                                thinkingText: viewModel.thinkingText
+                            )
+                            .id("streaming")
+                            .environmentObject(engine)
+                        }
+                        Color.clear.frame(height: 1).id("bottom")
+                    }
+                    .padding(.horizontal, 14)
+                    .padding(.top, 12)
+                    .padding(.bottom, 8)
+                }
+            }
+            .scrollDismissesKeyboard(.interactively)
+            .onTapGesture { inputFocused = false }
+            .onChange(of: viewModel.streamingText) { _, _ in
+                withAnimation(.easeOut(duration: 0.1)) {
+                    proxy.scrollTo("bottom")
+                }
+            }
+        }
     }
 
     // MARK: — Empty State
@@ -74,175 +85,262 @@ struct ChatView: View {
     @ViewBuilder
     private var emptyStateView: some View {
         switch engine.state {
+
         case .downloading(let progress, let speed):
-            VStack(spacing: 16) {
-                ZStack {
-                    Circle()
-                        .stroke(Color.blue.opacity(0.15), lineWidth: 6)
-                        .frame(width: 72, height: 72)
-                    Circle()
-                        .trim(from: 0, to: progress)
-                        .stroke(Color.blue, style: StrokeStyle(lineWidth: 6, lineCap: .round))
-                        .rotationEffect(.degrees(-90))
-                        .frame(width: 72, height: 72)
-                        .animation(.linear(duration: 0.3), value: progress)
-                    Text("\(Int(progress * 100))%")
-                        .font(.caption.monospacedDigit().weight(.semibold))
-                }
-                VStack(spacing: 4) {
+            VStack(spacing: 20) {
+                downloadRing(progress: progress)
+                VStack(spacing: 6) {
                     Text("Downloading model…")
                         .font(.headline)
+                        .foregroundStyle(SwiftLMTheme.textPrimary)
                     Text(speed.isEmpty ? "Preparing…" : speed)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(SwiftLMTheme.textSecondary)
                 }
                 Text("You'll be able to chat once the download completes.")
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(SwiftLMTheme.textTertiary)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, 40)
             }
+
         case .loading:
-            VStack(spacing: 12) {
-                ProgressView().controlSize(.large)
+            VStack(spacing: 16) {
+                ZStack {
+                    Circle()
+                        .stroke(SwiftLMTheme.accent.opacity(0.15), lineWidth: 3)
+                        .frame(width: 64, height: 64)
+                    ProgressView()
+                        .controlSize(.large)
+                        .tint(SwiftLMTheme.accent)
+                }
                 Text("Loading model into Metal GPU…")
                     .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(SwiftLMTheme.textSecondary)
             }
+
         case .idle:
-            VStack(spacing: 12) {
-                Image(systemName: "cpu")
-                    .font(.system(size: 48))
-                    .foregroundStyle(.tertiary)
-                Text("No model loaded")
-                    .font(.headline)
-                Text("Go to the Models tab to download and select a model.")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, 40)
-            }
+            idleEmptyState
+
         case .error(let msg):
-            VStack(spacing: 12) {
+            VStack(spacing: 14) {
                 Image(systemName: "exclamationmark.triangle.fill")
-                    .font(.system(size: 48))
-                    .foregroundStyle(.red)
+                    .font(.system(size: 44))
+                    .foregroundStyle(SwiftLMTheme.error)
                 Text("Load failed")
                     .font(.headline)
+                    .foregroundStyle(SwiftLMTheme.textPrimary)
                 Text(msg)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(SwiftLMTheme.textSecondary)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, 40)
             }
+
         case .ready, .generating:
-            VStack(spacing: 12) {
-                Image(systemName: "bubble.left.and.bubble.right")
-                    .font(.system(size: 48))
-                    .foregroundStyle(.tertiary)
+            VStack(spacing: 14) {
+                // Brand mark
+                brandMark
                 Text("Start a conversation")
                     .font(.headline)
+                    .foregroundStyle(SwiftLMTheme.textPrimary)
                 Text("Type a message below to begin.")
                     .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(SwiftLMTheme.textSecondary)
             }
         }
     }
 
-    // MARK: — Engine State Banner
+    // Brand mark — animated bolt in gradient ring
+    private var brandMark: some View {
+        ZStack {
+            Circle()
+                .fill(SwiftLMTheme.heroGradient)
+                .frame(width: 80, height: 80)
+                .shadow(color: SwiftLMTheme.accent.opacity(0.35), radius: 18)
+
+            Image(systemName: "bolt.fill")
+                .font(.system(size: 34, weight: .semibold))
+                .foregroundStyle(
+                    LinearGradient(colors: [.white, SwiftLMTheme.cyan],
+                                   startPoint: .top, endPoint: .bottom)
+                )
+        }
+    }
+
+    // Idle empty state — brand mark + tagline
+    private var idleEmptyState: some View {
+        VStack(spacing: 20) {
+            brandMark
+
+            VStack(spacing: 6) {
+                Text("SwiftLM Chat")
+                    .font(.title2.weight(.bold))
+                    .foregroundStyle(SwiftLMTheme.textPrimary)
+
+                Text("Run any model. Locally. Instantly.")
+                    .font(.subheadline)
+                    .foregroundStyle(
+                        LinearGradient(
+                            colors: [SwiftLMTheme.accent, SwiftLMTheme.cyan],
+                            startPoint: .leading, endPoint: .trailing
+                        )
+                    )
+            }
+
+            Text("Go to the **Models** tab to download\na model and start chatting.")
+                .font(.caption)
+                .foregroundStyle(SwiftLMTheme.textTertiary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 40)
+        }
+    }
+
+    // Download ring
+    private func downloadRing(progress: Double) -> some View {
+        ZStack {
+            Circle()
+                .stroke(SwiftLMTheme.accent.opacity(0.15), lineWidth: 6)
+            Circle()
+                .trim(from: 0, to: progress)
+                .stroke(
+                    SwiftLMTheme.avatarGradient,
+                    style: StrokeStyle(lineWidth: 6, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+                .animation(.linear(duration: 0.3), value: progress)
+            Text("\(Int(progress * 100))%")
+                .font(.caption.monospacedDigit().weight(.semibold))
+                .foregroundStyle(SwiftLMTheme.textPrimary)
+        }
+        .frame(width: 72, height: 72)
+    }
+
+    // MARK: — Engine Banner (slim status strip above input)
 
     @ViewBuilder
     private var engineBanner: some View {
         switch engine.state {
         case .idle:
-            HStack(spacing: 8) {
-                Image(systemName: "cpu").foregroundStyle(.secondary)
-                Text("No model loaded — tap Models to get started")
-                    .font(.caption).foregroundStyle(.secondary)
-                Spacer()
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 8)
-            .background(Color(.systemGray6))
+            bannerRow(icon: "cpu", text: "No model loaded", color: SwiftLMTheme.textTertiary)
         case .loading:
             HStack(spacing: 8) {
-                ProgressView().controlSize(.mini)
+                ProgressView().controlSize(.mini).tint(SwiftLMTheme.accent)
                 Text("Loading model…")
-                    .font(.caption).foregroundStyle(.secondary)
+                    .font(.caption)
+                    .foregroundStyle(SwiftLMTheme.textSecondary)
                 Spacer()
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 8)
-            .background(Color(.systemGray6))
-        case .downloading(let progress, let speed):
+            .background(SwiftLMTheme.surface.opacity(0.90))
+        case .downloading(let p, let speed):
             VStack(alignment: .leading, spacing: 4) {
                 HStack {
                     Text("Downloading…")
                         .font(.caption.weight(.medium))
+                        .foregroundStyle(SwiftLMTheme.textSecondary)
                     Spacer()
-                    Text("\(Int(progress * 100))% · \(speed)")
+                    Text("\(Int(p * 100))% · \(speed)")
                         .font(.caption2.monospacedDigit())
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(SwiftLMTheme.textTertiary)
                 }
-                ProgressView(value: progress).tint(.blue)
+                ProgressView(value: p).tint(SwiftLMTheme.accent)
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 8)
-            .background(Color(.systemGray6))
+            .background(SwiftLMTheme.surface.opacity(0.90))
         case .error(let msg):
-            HStack(spacing: 8) {
-                Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.red)
-                Text(msg).font(.caption).foregroundStyle(.red).lineLimit(2)
-                Spacer()
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 8)
-            .background(Color(.systemGray6))
+            bannerRow(icon: "exclamationmark.triangle.fill", text: msg, color: SwiftLMTheme.error)
         case .ready, .generating:
             EmptyView()
         }
     }
 
+    private func bannerRow(icon: String, text: String, color: Color) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon).foregroundStyle(color)
+            Text(text)
+                .font(.caption)
+                .foregroundStyle(color)
+                .lineLimit(2)
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .background(SwiftLMTheme.surface.opacity(0.90))
+    }
+
     // MARK: — Input Bar
 
     private var inputBar: some View {
-        HStack(alignment: .bottom, spacing: 8) {
-            TextField("Message", text: $inputText, axis: .vertical)
-                .textFieldStyle(.plain)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
-                .background(Color(.systemGray).opacity(0.1))
-                .clipShape(RoundedRectangle(cornerRadius: 20))
-                .lineLimit(1...8)
-                .focused($inputFocused)
-                .onSubmit {
-                    #if os(macOS)
-                    sendMessage()
-                    #endif
-                }
-                .disabled(!engine.state.canSend)
+        HStack(alignment: .bottom, spacing: 10) {
+            // Text field with frosted glass pill
+            HStack(alignment: .bottom) {
+                TextField("Message", text: $inputText, axis: .vertical)
+                    .textFieldStyle(.plain)
+                    .font(.system(.body))
+                    .foregroundStyle(SwiftLMTheme.textPrimary)
+                    .lineLimit(1...8)
+                    .focused($inputFocused)
+                    .onSubmit {
+                        #if os(macOS)
+                        sendMessage()
+                        #endif
+                    }
+                    .disabled(!engine.state.canSend)
+                    .accentColor(SwiftLMTheme.accent)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(.ultraThinMaterial)
+            .background(SwiftLMTheme.surface.opacity(0.70))
+            .clipShape(RoundedRectangle(cornerRadius: SwiftLMTheme.radiusXL))
+            .overlay(
+                RoundedRectangle(cornerRadius: SwiftLMTheme.radiusXL)
+                    .strokeBorder(
+                        inputFocused
+                            ? SwiftLMTheme.accent.opacity(0.55)
+                            : Color.white.opacity(0.08),
+                        lineWidth: inputFocused ? 1.5 : 1
+                    )
+                    .animation(SwiftLMTheme.quickSpring, value: inputFocused)
+            )
+            .glowRing(active: inputFocused)
 
+            // Send / Stop button
             if viewModel.isGenerating {
                 Button(action: viewModel.stopGeneration) {
-                    Image(systemName: "stop.circle.fill")
-                        .font(.title2)
-                        .foregroundStyle(.red)
+                    ZStack {
+                        Circle()
+                            .fill(SwiftLMTheme.error.opacity(0.18))
+                            .frame(width: 40, height: 40)
+                        Image(systemName: "stop.fill")
+                            .font(.system(size: 14, weight: .bold))
+                            .foregroundStyle(SwiftLMTheme.error)
+                    }
                 }
                 .buttonStyle(.plain)
             } else {
                 Button(action: sendMessage) {
-                    Image(systemName: "arrow.up.circle.fill")
-                        .font(.title2)
-                        .foregroundStyle(canSend ? .blue : .gray)
+                    ZStack {
+                        Circle()
+                            .fill(canSend ? AnyShapeStyle(SwiftLMTheme.userBubbleGradient) : AnyShapeStyle(Color.white.opacity(0.08)))
+                            .frame(width: 40, height: 40)
+                        Image(systemName: "arrow.up")
+                            .font(.system(size: 15, weight: .bold))
+                            .foregroundStyle(canSend ? .white : SwiftLMTheme.textTertiary)
+                    }
                 }
                 .buttonStyle(.plain)
                 .disabled(!canSend)
                 .keyboardShortcut(.return, modifiers: .command)
+                .animation(SwiftLMTheme.quickSpring, value: canSend)
             }
         }
         .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-        .background(.regularMaterial)
+        .padding(.vertical, 10)
+        .background(SwiftLMTheme.background.opacity(0.95))
     }
 
     private var canSend: Bool {
@@ -261,43 +359,49 @@ struct ChatView: View {
     #if os(iOS)
     @ToolbarContentBuilder
     private var iOSToolbar: some ToolbarContent {
-        // Model status pill (center)
+        // Animated status pill (center)
         ToolbarItem(placement: .principal) {
             modelStatusPill
         }
-        // Dismiss keyboard when focused — lets user reach the tab bar
+        // Keyboard dismiss
         ToolbarItem(placement: .topBarLeading) {
             if inputFocused {
-                Button {
-                    inputFocused = false
-                } label: {
+                Button { inputFocused = false } label: {
                     Image(systemName: "keyboard.chevron.compact.down")
+                        .foregroundStyle(SwiftLMTheme.textSecondary)
                 }
                 .transition(.opacity)
             }
         }
         // New conversation
         ToolbarItem(placement: .topBarTrailing) {
-            Button {
-                viewModel.newConversation()
-            } label: {
+            Button { viewModel.newConversation() } label: {
                 Image(systemName: "square.and.pencil")
+                    .foregroundStyle(SwiftLMTheme.accent)
             }
         }
     }
 
     private var modelStatusPill: some View {
         HStack(spacing: 5) {
-            Circle()
-                .fill(engine.state.statusColor)
-                .frame(width: 7, height: 7)
+            if case .generating = engine.state {
+                GeneratingDots()
+            } else {
+                Circle()
+                    .fill(engine.state.statusColor)
+                    .frame(width: 7, height: 7)
+            }
             Text(engine.state.shortLabel)
                 .font(.caption.weight(.medium))
+                .foregroundStyle(SwiftLMTheme.textPrimary)
                 .lineLimit(1)
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 4)
-        .background(.regularMaterial, in: Capsule())
+        .padding(.horizontal, 12)
+        .padding(.vertical, 5)
+        .background(.ultraThinMaterial)
+        .background(SwiftLMTheme.surface.opacity(0.70))
+        .clipShape(Capsule())
+        .overlay(Capsule().strokeBorder(Color.white.opacity(0.09), lineWidth: 1))
     }
     #endif
 
@@ -328,22 +432,22 @@ extension ModelState {
 
     var statusColor: Color {
         switch self {
-        case .idle:                        return .gray
-        case .loading, .downloading:       return .orange
-        case .ready:                       return .green
-        case .generating:                  return .blue
-        case .error:                       return .red
+        case .idle:                       return SwiftLMTheme.textTertiary
+        case .loading, .downloading:      return SwiftLMTheme.warning
+        case .ready:                      return SwiftLMTheme.success
+        case .generating:                 return SwiftLMTheme.accent
+        case .error:                      return SwiftLMTheme.error
         }
     }
 
     var shortLabel: String {
         switch self {
-        case .idle:                          return "No model"
-        case .loading:                       return "Loading…"
-        case .downloading(let p, _):         return "\(Int(p * 100))% downloading"
-        case .ready(let modelId):            return modelId.components(separatedBy: "/").last ?? modelId
-        case .generating:                    return "Generating…"
-        case .error:                         return "Error"
+        case .idle:                        return "No model"
+        case .loading:                     return "Loading…"
+        case .downloading(let p, _):       return "\(Int(p * 100))% downloading"
+        case .ready(let modelId):          return modelId.components(separatedBy: "/").last ?? modelId
+        case .generating:                  return "Generating"
+        case .error:                       return "Error"
         }
     }
 }

--- a/SwiftLMChat/SwiftLMChat/Views/MessageBubble.swift
+++ b/SwiftLMChat/SwiftLMChat/Views/MessageBubble.swift
@@ -1,198 +1,319 @@
-// MessageBubble.swift — Chat message bubble + live streaming bubble
+// MessageBubble.swift — Premium chat message bubbles (iOS + macOS)
 import SwiftUI
 
-// MARK: — Shared adaptive colors
-
-private extension Color {
-    /// Assistant bubble background — works in both light and dark mode.
-    /// Light mode: warm near-white. Dark mode: elevated dark fill.
-    static var assistantBubble: Color {
-        #if os(macOS)
-        return Color(NSColor.controlBackgroundColor)
-        #else
-        return Color(UIColor.secondarySystemBackground)
-        #endif
-    }
-
-    /// Subtle inner tint for thinking disclosure group.
-    static var thinkingBubble: Color {
-        #if os(macOS)
-        return Color(NSColor.windowBackgroundColor)
-        #else
-        return Color(UIColor.tertiarySystemBackground)
-        #endif
-    }
-}
-
+// ─────────────────────────────────────────────────────────────────────────────
 // MARK: — Static Message Bubble
+// ─────────────────────────────────────────────────────────────────────────────
 
 struct MessageBubble: View {
     let message: ChatMessage
+    @State private var showTimestamp = false
+    @EnvironmentObject private var engine: InferenceEngine
 
     var isUser: Bool { message.role == .user }
 
     var body: some View {
         HStack(alignment: .bottom, spacing: 8) {
-            if isUser { Spacer(minLength: 60) }
+            if isUser { Spacer(minLength: 52) }
 
             if !isUser {
-                // Avatar
-                Circle()
-                    .fill(LinearGradient(
-                        colors: [.blue, .purple],
-                        startPoint: .topLeading, endPoint: .bottomTrailing
-                    ))
-                    .frame(width: 28, height: 28)
-                    .overlay(
-                        Image(systemName: "cpu")
-                            .font(.system(size: 11, weight: .semibold))
-                            .foregroundStyle(.white)
-                    )
+                AvatarView(
+                    isGenerating: false,
+                    size: 30
+                )
             }
 
             VStack(alignment: isUser ? .trailing : .leading, spacing: 4) {
-                Text(message.content)
-                    .font(.system(.body, design: .default))
-                    .textSelection(.enabled)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-                    .background(isUser ? Color.accentColor : Color.assistantBubble)
-                    .foregroundStyle(isUser ? .white : .primary)
-                    .clipShape(BubbleShape(isUser: isUser))
-                    .shadow(color: .black.opacity(0.06), radius: 2, x: 0, y: 1)
+                if isUser {
+                    userBubble
+                } else {
+                    assistantBubble
+                }
 
-                Text(message.timestamp, style: .time)
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
+                if showTimestamp {
+                    Text(message.timestamp, style: .time)
+                        .font(.caption2)
+                        .foregroundStyle(SwiftLMTheme.textTertiary)
+                        .transition(.opacity.combined(with: .move(edge: .top)))
+                }
+            }
+            .onTapGesture {
+                withAnimation(SwiftLMTheme.quickSpring) {
+                    showTimestamp.toggle()
+                }
             }
 
-            if !isUser { Spacer(minLength: 60) }
+            if !isUser { Spacer(minLength: 52) }
         }
+    }
+
+    // MARK: — User Bubble
+
+    private var userBubble: some View {
+        Text(message.content)
+            .font(.system(.body, design: .default))
+            .textSelection(.enabled)
+            .foregroundStyle(.white)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(SwiftLMTheme.userBubbleGradient)
+            .clipShape(UserBubbleShape())
+            .shadow(
+                color: SwiftLMTheme.accent.opacity(0.30),
+                radius: 6, x: 0, y: 3
+            )
+    }
+
+    // MARK: — Assistant Bubble
+
+    private var assistantBubble: some View {
+        Text(message.content)
+            .font(.system(.body, design: .default))
+            .textSelection(.enabled)
+            .foregroundStyle(SwiftLMTheme.textPrimary)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(.ultraThinMaterial)
+            .background(SwiftLMTheme.surface.opacity(0.80))
+            .clipShape(AssistantBubbleShape())
+            .overlay(
+                AssistantBubbleShape()
+                    .stroke(Color.white.opacity(0.08), lineWidth: 1)
+            )
+            .shadow(
+                color: SwiftLMTheme.shadowBubble.color,
+                radius: SwiftLMTheme.shadowBubble.radius,
+                x: SwiftLMTheme.shadowBubble.x,
+                y: SwiftLMTheme.shadowBubble.y
+            )
     }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
 // MARK: — Live Streaming Bubble
+// ─────────────────────────────────────────────────────────────────────────────
 
 struct StreamingBubble: View {
     let text: String
     let thinkingText: String?
-    @State private var cursorVisible = true
+
+    @EnvironmentObject private var engine: InferenceEngine
+    @State private var thinkingExpanded = true
 
     var body: some View {
         HStack(alignment: .bottom, spacing: 8) {
-            Circle()
-                .fill(LinearGradient(
-                    colors: [.blue, .purple],
-                    startPoint: .topLeading, endPoint: .bottomTrailing
-                ))
-                .frame(width: 28, height: 28)
-                .overlay(
-                    Image(systemName: "cpu")
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(.white)
-                )
+            AvatarView(isGenerating: true, size: 30)
 
             VStack(alignment: .leading, spacing: 6) {
-                // Thinking section
+                // ── Thinking section ─────────────────────────────────────────
                 if let thinking = thinkingText, !thinking.isEmpty {
-                    DisclosureGroup {
-                        Text(thinking)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .padding(8)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .background(Color.thinkingBubble, in: RoundedRectangle(cornerRadius: 8))
-                    } label: {
-                        Label("Thinking…", systemImage: "brain")
-                            .font(.caption.weight(.medium))
-                            .foregroundStyle(.secondary)
-                    }
+                    ThinkingPanel(text: thinking, isExpanded: $thinkingExpanded)
                 }
 
-                // Response text
+                // ── Response text ────────────────────────────────────────────
                 if !text.isEmpty {
-                    HStack(alignment: .bottom, spacing: 2) {
-                        Text(text)
-                            .font(.system(.body, design: .default))
-                            .foregroundStyle(.primary)
-                            .textSelection(.enabled)
-                        // Blinking cursor
-                        RoundedRectangle(cornerRadius: 1)
-                            .frame(width: 2, height: 16)
-                            .foregroundStyle(.blue)
-                            .opacity(cursorVisible ? 1 : 0)
-                            .animation(.easeInOut(duration: 0.5).repeatForever(), value: cursorVisible)
-                    }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-                    .background(Color.assistantBubble)
-                    .clipShape(BubbleShape(isUser: false))
-                    .shadow(color: .black.opacity(0.06), radius: 2, x: 0, y: 1)
-                } else {
-                    TypingIndicator()
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 10)
-                        .background(Color.assistantBubble)
-                        .clipShape(BubbleShape(isUser: false))
+                    streamingText
+                } else if thinkingText == nil || thinkingText?.isEmpty == true {
+                    // Show typing indicator only when there's no content at all
+                    typingDots
                 }
             }
 
-            Spacer(minLength: 60)
+            Spacer(minLength: 52)
         }
-        .onAppear { cursorVisible = false }
+    }
+
+    private var streamingText: some View {
+        // Inline blinking cursor via attributed string approach
+        HStack(alignment: .bottom, spacing: 0) {
+            Text(text)
+                .font(.system(.body, design: .default))
+                .foregroundStyle(SwiftLMTheme.textPrimary)
+                .textSelection(.enabled)
+            BlinkingCursor()
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(.ultraThinMaterial)
+        .background(SwiftLMTheme.surface.opacity(0.80))
+        .clipShape(AssistantBubbleShape())
+        .overlay(
+            AssistantBubbleShape()
+                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+        )
+        .shadow(
+            color: SwiftLMTheme.shadowBubble.color,
+            radius: SwiftLMTheme.shadowBubble.radius,
+            x: SwiftLMTheme.shadowBubble.x,
+            y: SwiftLMTheme.shadowBubble.y
+        )
+    }
+
+    private var typingDots: some View {
+        HStack(spacing: 5) {
+            ForEach(0..<3, id: \.self) { i in
+                BouncingDot(index: i)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(.ultraThinMaterial)
+        .background(SwiftLMTheme.surface.opacity(0.80))
+        .clipShape(AssistantBubbleShape())
+        .overlay(
+            AssistantBubbleShape()
+                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+        )
     }
 }
 
-// MARK: — Typing Indicator
+// ─────────────────────────────────────────────────────────────────────────────
+// MARK: — Thinking Panel
+// ─────────────────────────────────────────────────────────────────────────────
 
-struct TypingIndicator: View {
-    @State private var phase = 0
+private struct ThinkingPanel: View {
+    let text: String
+    @Binding var isExpanded: Bool
 
     var body: some View {
-        HStack(spacing: 5) {
-            ForEach(0..<3) { i in
-                Circle()
-                    .frame(width: 7, height: 7)
-                    .foregroundStyle(.secondary)
-                    .scaleEffect(phase == i ? 1.4 : 0.8)
-                    .animation(
-                        .easeInOut(duration: 0.45)
-                            .repeatForever()
-                            .delay(Double(i) * 0.15),
-                        value: phase
-                    )
+        VStack(alignment: .leading, spacing: 0) {
+            // Header toggle
+            Button {
+                withAnimation(SwiftLMTheme.spring) { isExpanded.toggle() }
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "brain.filled.head.profile")
+                        .font(.caption)
+                        .foregroundStyle(SwiftLMTheme.accentSecondary)
+                    Text("Thinking…")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(SwiftLMTheme.accentSecondary)
+                    Spacer()
+                    Image(systemName: "chevron.down")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(SwiftLMTheme.textTertiary)
+                        .rotationEffect(.degrees(isExpanded ? 0 : -90))
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 7)
+            }
+            .buttonStyle(.plain)
+
+            // Expandable content
+            if isExpanded {
+                ScrollView {
+                    Text(text)
+                        .font(.caption)
+                        .foregroundStyle(SwiftLMTheme.textSecondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(10)
+                }
+                .frame(maxHeight: 160)
             }
         }
-        .onAppear { withAnimation { phase = 1 } }
+        .background(SwiftLMTheme.thinkingGradient)
+        .clipShape(RoundedRectangle(cornerRadius: SwiftLMTheme.radiusMedium))
+        .overlay(
+            RoundedRectangle(cornerRadius: SwiftLMTheme.radiusMedium)
+                .strokeBorder(SwiftLMTheme.accentSecondary.opacity(0.20), lineWidth: 1)
+        )
     }
 }
 
-// MARK: — Bubble Shape
+// ─────────────────────────────────────────────────────────────────────────────
+// MARK: — Blinking Cursor
+// ─────────────────────────────────────────────────────────────────────────────
 
-struct BubbleShape: Shape {
-    let isUser: Bool
-    let radius: CGFloat = 18
+private struct BlinkingCursor: View {
+    @State private var visible = true
 
+    var body: some View {
+        RoundedRectangle(cornerRadius: 1.5)
+            .frame(width: 2.5, height: 17)
+            .foregroundStyle(SwiftLMTheme.accent)
+            .opacity(visible ? 1 : 0)
+            .animation(
+                .easeInOut(duration: 0.52).repeatForever(autoreverses: true),
+                value: visible
+            )
+            .onAppear { visible = false }
+            .padding(.leading, 1)
+            .padding(.bottom, 1)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MARK: — Bouncing Dots (typing indicator)
+// ─────────────────────────────────────────────────────────────────────────────
+
+private struct BouncingDot: View {
+    let index: Int
+    @State private var bouncing = false
+
+    var body: some View {
+        Circle()
+            .frame(width: 7, height: 7)
+            .foregroundStyle(SwiftLMTheme.textSecondary)
+            .offset(y: bouncing ? -5 : 0)
+            .animation(
+                .easeInOut(duration: 0.45)
+                    .repeatForever(autoreverses: true)
+                    .delay(Double(index) * 0.14),
+                value: bouncing
+            )
+            .onAppear { bouncing = true }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MARK: — Bubble Shapes
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// User bubble: rounded top-left + bottom, small top-right corner.
+struct UserBubbleShape: Shape {
+    let r: CGFloat = 18
     func path(in rect: CGRect) -> Path {
-        let tl: CGFloat = isUser ? radius : 4
-        let tr: CGFloat = isUser ? 4  : radius
-        let bl: CGFloat = radius
-        let br: CGFloat = radius
-        var path = Path()
-        path.move(to: CGPoint(x: rect.minX + tl, y: rect.minY))
-        path.addLine(to: CGPoint(x: rect.maxX - tr, y: rect.minY))
-        path.addQuadCurve(to: CGPoint(x: rect.maxX, y: rect.minY + tr),
-                          control: CGPoint(x: rect.maxX, y: rect.minY))
-        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY - br))
-        path.addQuadCurve(to: CGPoint(x: rect.maxX - br, y: rect.maxY),
-                          control: CGPoint(x: rect.maxX, y: rect.maxY))
-        path.addLine(to: CGPoint(x: rect.minX + bl, y: rect.maxY))
-        path.addQuadCurve(to: CGPoint(x: rect.minX, y: rect.maxY - bl),
-                          control: CGPoint(x: rect.minX, y: rect.maxY))
-        path.addLine(to: CGPoint(x: rect.minX, y: rect.minY + tl))
-        path.addQuadCurve(to: CGPoint(x: rect.minX + tl, y: rect.minY),
-                          control: CGPoint(x: rect.minX, y: rect.minY))
-        path.closeSubpath()
-        return path
+        var p = Path()
+        p.move(to: CGPoint(x: rect.minX + r, y: rect.minY))
+        p.addLine(to: CGPoint(x: rect.maxX - 4, y: rect.minY))
+        p.addQuadCurve(to: CGPoint(x: rect.maxX, y: rect.minY + 4),
+                       control: CGPoint(x: rect.maxX, y: rect.minY))
+        p.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY - r))
+        p.addQuadCurve(to: CGPoint(x: rect.maxX - r, y: rect.maxY),
+                       control: CGPoint(x: rect.maxX, y: rect.maxY))
+        p.addLine(to: CGPoint(x: rect.minX + r, y: rect.maxY))
+        p.addQuadCurve(to: CGPoint(x: rect.minX, y: rect.maxY - r),
+                       control: CGPoint(x: rect.minX, y: rect.maxY))
+        p.addLine(to: CGPoint(x: rect.minX, y: rect.minY + r))
+        p.addQuadCurve(to: CGPoint(x: rect.minX + r, y: rect.minY),
+                       control: CGPoint(x: rect.minX, y: rect.minY))
+        p.closeSubpath()
+        return p
     }
 }
+
+/// Assistant bubble: small top-left (tail side), large radii elsewhere.
+struct AssistantBubbleShape: Shape {
+    let r: CGFloat = 18
+    func path(in rect: CGRect) -> Path {
+        var p = Path()
+        p.move(to: CGPoint(x: rect.minX + 4, y: rect.minY))
+        p.addLine(to: CGPoint(x: rect.maxX - r, y: rect.minY))
+        p.addQuadCurve(to: CGPoint(x: rect.maxX, y: rect.minY + r),
+                       control: CGPoint(x: rect.maxX, y: rect.minY))
+        p.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY - r))
+        p.addQuadCurve(to: CGPoint(x: rect.maxX - r, y: rect.maxY),
+                       control: CGPoint(x: rect.maxX, y: rect.maxY))
+        p.addLine(to: CGPoint(x: rect.minX + r, y: rect.maxY))
+        p.addQuadCurve(to: CGPoint(x: rect.minX, y: rect.maxY - r),
+                       control: CGPoint(x: rect.minX, y: rect.maxY))
+        p.addLine(to: CGPoint(x: rect.minX, y: rect.minY + 4))
+        p.addQuadCurve(to: CGPoint(x: rect.minX + 4, y: rect.minY),
+                       control: CGPoint(x: rect.minX, y: rect.minY))
+        p.closeSubpath()
+        return p
+    }
+}
+
+// Keep BubbleShape for any legacy reference
+typealias BubbleShape = UserBubbleShape

--- a/SwiftLMChat/SwiftLMChat/Views/ModelsView.swift
+++ b/SwiftLMChat/SwiftLMChat/Views/ModelsView.swift
@@ -1,4 +1,4 @@
-// ModelsView.swift — Unified iOS-first Models tab
+// ModelsView.swift — Unified iOS-first Models tab (premium theme)
 // Combines: active model, downloads in progress, downloaded list, catalog, HF search
 import SwiftUI
 
@@ -13,126 +13,158 @@ struct ModelsView: View {
     private var dm: ModelDownloadManager { engine.downloadManager }
 
     var body: some View {
-        ScrollView {
-            LazyVStack(alignment: .leading, spacing: 0) {
-                // ── 1. Active model hero card ─────────────────────────────
-                activeModelCard
-                    .padding(.horizontal)
-                    .padding(.top, 16)
-                    .padding(.bottom, 12)
+        ZStack {
+            SwiftLMTheme.background.ignoresSafeArea()
 
-                // ── 2. Active downloads (live) ────────────────────────────
-                if !dm.activeDownloads.isEmpty {
-                    sectionHeader("Downloading")
-                    ForEach(Array(dm.activeDownloads.keys), id: \.self) { modelId in
-                        if let progress = dm.activeDownloads[modelId] {
-                            DownloadProgressCard(modelId: modelId, progress: progress)
-                                .padding(.horizontal)
-                                .padding(.bottom, 8)
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    // ── 1. Active model hero card ──────────────────────────
+                    activeModelCard
+                        .padding(.horizontal)
+                        .padding(.top, 16)
+                        .padding(.bottom, 14)
+
+                    // ── 2. Active downloads ────────────────────────────────
+                    if !dm.activeDownloads.isEmpty {
+                        sectionHeader("Downloading")
+                        ForEach(Array(dm.activeDownloads.keys), id: \.self) { modelId in
+                            if let progress = dm.activeDownloads[modelId] {
+                                DownloadProgressCard(modelId: modelId, progress: progress)
+                                    .padding(.horizontal)
+                                    .padding(.bottom, 10)
+                            }
                         }
                     }
-                }
 
-                // ── 3. Downloaded models ──────────────────────────────────
-                if !dm.downloadedModels.isEmpty {
-                    sectionHeader("Downloaded (\(dm.downloadedModels.count))")
-                        .padding(.top, 4)
-                    ForEach(dm.downloadedModels) { downloaded in
-                        let entry = ModelCatalog.all.first(where: { $0.id == downloaded.id })
-                        let isActive: Bool = {
-                            if case .ready(let id) = engine.state { return id == downloaded.id }
-                            return false
-                        }()
-                        DownloadedModelRow(
-                            downloaded: downloaded,
-                            entry: entry,
-                            isActive: isActive,
-                            onLoad: { Task { await engine.load(modelId: downloaded.id) } },
-                            onDelete: { try? dm.delete(downloaded.id) }
+                    // ── 3. Downloaded models ───────────────────────────────
+                    if !dm.downloadedModels.isEmpty {
+                        sectionHeader("Downloaded (\(dm.downloadedModels.count))")
+                            .padding(.top, 4)
+                        VStack(spacing: 0) {
+                            ForEach(dm.downloadedModels) { downloaded in
+                                let entry = ModelCatalog.all.first(where: { $0.id == downloaded.id })
+                                let isActive: Bool = {
+                                    if case .ready(let id) = engine.state { return id == downloaded.id }
+                                    return false
+                                }()
+                                DownloadedModelRow(
+                                    downloaded: downloaded,
+                                    entry: entry,
+                                    isActive: isActive,
+                                    onLoad: { Task { await engine.load(modelId: downloaded.id) } },
+                                    onDelete: { try? dm.delete(downloaded.id) }
+                                )
+                                .padding(.horizontal)
+                                if downloaded.id != dm.downloadedModels.last?.id {
+                                    Divider()
+                                        .background(SwiftLMTheme.divider)
+                                        .padding(.leading, 72)
+                                }
+                            }
+                        }
+                        .background(SwiftLMTheme.surface.opacity(0.60))
+                        .clipShape(RoundedRectangle(cornerRadius: SwiftLMTheme.radiusMedium))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: SwiftLMTheme.radiusMedium)
+                                .strokeBorder(Color.white.opacity(0.07), lineWidth: 1)
                         )
                         .padding(.horizontal)
-                        if downloaded.id != dm.downloadedModels.last?.id {
-                            Divider().padding(.leading, 72)
-                        }
+                        .padding(.bottom, 10)
                     }
-                    .padding(.bottom, 8)
-                }
 
-                // ── 4. Catalog — recommended ──────────────────────────────
-                let recommended = dm.modelsForDevice()
-                    .filter { !dm.isDownloaded($0.id) }
-                if !recommended.isEmpty {
-                    sectionHeader("Recommended for your \(String(format: "%.0f GB", device.physicalRAMGB)) device")
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: 12) {
-                            ForEach(recommended) { model in
-                                CatalogCard(
+                    // ── 4. Recommended for device ──────────────────────────
+                    let recommended = dm.modelsForDevice()
+                        .filter { !dm.isDownloaded($0.id) }
+                    if !recommended.isEmpty {
+                        sectionHeader("Recommended for \(String(format: "%.0f GB", device.physicalRAMGB)) RAM")
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: 12) {
+                                ForEach(recommended) { model in
+                                    CatalogCard(
+                                        model: model,
+                                        fitStatus: ModelCatalog.fitStatus(for: model, on: device),
+                                        onTap: { handleSelect(model.id) }
+                                    )
+                                }
+                            }
+                            .padding(.horizontal)
+                            .padding(.bottom, 4)
+                        }
+                        .padding(.bottom, 10)
+                    }
+
+                    // ── 5. All Models ──────────────────────────────────────
+                    let others = ModelCatalog.all
+                        .filter { model in
+                            !dm.isDownloaded(model.id) &&
+                            !recommended.contains(where: { $0.id == model.id })
+                        }
+                    if !others.isEmpty {
+                        sectionHeader("All Models")
+                        VStack(spacing: 0) {
+                            ForEach(others) { model in
+                                CatalogListRow(
                                     model: model,
                                     fitStatus: ModelCatalog.fitStatus(for: model, on: device),
                                     onTap: { handleSelect(model.id) }
                                 )
+                                .padding(.horizontal)
+                                if model.id != others.last?.id {
+                                    Divider()
+                                        .background(SwiftLMTheme.divider)
+                                        .padding(.leading, 56)
+                                }
                             }
                         }
-                        .padding(.horizontal)
-                        .padding(.bottom, 4)
-                    }
-                    .padding(.bottom, 8)
-                }
-
-                // ── 5. Catalog — all models ───────────────────────────────
-                let others = ModelCatalog.all
-                    .filter { model in
-                        !dm.isDownloaded(model.id) &&
-                        !recommended.contains(where: { $0.id == model.id })
-                    }
-                if !others.isEmpty {
-                    sectionHeader("All Models")
-                    ForEach(others) { model in
-                        CatalogListRow(
-                            model: model,
-                            fitStatus: ModelCatalog.fitStatus(for: model, on: device),
-                            onTap: { handleSelect(model.id) }
+                        .background(SwiftLMTheme.surface.opacity(0.60))
+                        .clipShape(RoundedRectangle(cornerRadius: SwiftLMTheme.radiusMedium))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: SwiftLMTheme.radiusMedium)
+                                .strokeBorder(Color.white.opacity(0.07), lineWidth: 1)
                         )
                         .padding(.horizontal)
-                        if model.id != others.last?.id {
-                            Divider().padding(.leading, 56)
+                        .padding(.bottom, 10)
+                    }
+
+                    // ── 6. HuggingFace search ──────────────────────────────
+                    Button { showHFSearch = true } label: {
+                        HStack {
+                            Image(systemName: "magnifyingglass")
+                                .foregroundStyle(SwiftLMTheme.accent)
+                            Text("Search HuggingFace MLX models")
+                                .foregroundStyle(SwiftLMTheme.textPrimary)
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.caption)
+                                .foregroundStyle(SwiftLMTheme.textTertiary)
                         }
+                        .padding(14)
+                        .background(SwiftLMTheme.surface.opacity(0.60))
+                        .clipShape(RoundedRectangle(cornerRadius: SwiftLMTheme.radiusMedium))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: SwiftLMTheme.radiusMedium)
+                                .strokeBorder(Color.white.opacity(0.07), lineWidth: 1)
+                        )
                     }
-                    .padding(.bottom, 8)
-                }
+                    .buttonStyle(.plain)
+                    .padding(.horizontal)
+                    .padding(.vertical, 8)
 
-                // ── 6. HuggingFace search ─────────────────────────────────
-                Button {
-                    showHFSearch = true
-                } label: {
-                    HStack {
-                        Image(systemName: "magnifyingglass")
-                        Text("Search HuggingFace MLX models")
-                        Spacer()
-                        Image(systemName: "chevron.right")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                    .padding()
-                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
-                    .foregroundStyle(.primary)
+                    Spacer(minLength: 32)
                 }
-                .buttonStyle(.plain)
-                .padding(.horizontal)
-                .padding(.vertical, 8)
-
-                Spacer(minLength: 32)
             }
         }
-        .background(Color(.systemGroupedBackground))
         .navigationTitle("Models")
+        #if os(iOS)
         .navigationBarTitleDisplayMode(.large)
+        .toolbarBackground(SwiftLMTheme.background.opacity(0.90), for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
+        #endif
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
-                Button {
-                    showManagement = true
-                } label: {
+                Button { showManagement = true } label: {
                     Image(systemName: "externaldrive.badge.minus")
+                        .foregroundStyle(SwiftLMTheme.accent)
                 }
             }
         }
@@ -149,100 +181,35 @@ struct ModelsView: View {
     // MARK: — Helpers
 
     private func sectionHeader(_ title: String) -> some View {
-        Text(title)
-            .font(.footnote.weight(.semibold))
-            .foregroundStyle(.secondary)
-            .textCase(.uppercase)
-            .padding(.horizontal)
-            .padding(.top, 20)
-            .padding(.bottom, 6)
+        HStack(spacing: 8) {
+            Text(title)
+                .font(.footnote.weight(.semibold))
+                .foregroundStyle(SwiftLMTheme.textTertiary)
+                .textCase(.uppercase)
+            Rectangle()
+                .fill(SwiftLMTheme.divider)
+                .frame(height: 1)
+        }
+        .padding(.horizontal)
+        .padding(.top, 20)
+        .padding(.bottom, 8)
     }
 
     private func handleSelect(_ modelId: String) {
         showHFSearch = false
-        // Don't clear the conversation — user can still read previous messages
-        // while the new model downloads. newConversation() is available from the Chat tab.
         Task { await engine.load(modelId: modelId) }
     }
 }
 
 // MARK: — Active Model Hero Card
 
-private struct ActiveModelHeroCard: View {
-    let modelId: String
-    let entry: ModelEntry?
-    let state: ModelState
-
-    var body: some View {
-        ZStack(alignment: .bottomLeading) {
-            // Gradient background
-            LinearGradient(
-                colors: [Color.teal.opacity(0.8), Color.blue.opacity(0.9)],
-                startPoint: .topLeading, endPoint: .bottomTrailing
-            )
-            .clipShape(RoundedRectangle(cornerRadius: 16))
-
-            VStack(alignment: .leading, spacing: 8) {
-                HStack {
-                    Text("Active Model")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.white.opacity(0.8))
-                    Spacer()
-                    stateBadge
-                }
-
-                Text(entry?.displayName ?? modelId.components(separatedBy: "/").last ?? modelId)
-                    .font(.title2.weight(.bold))
-                    .foregroundStyle(.white)
-                    .lineLimit(2)
-
-                HStack(spacing: 12) {
-                    if let entry {
-                        Label(String(format: "%.1f GB RAM", entry.ramRequiredGB), systemImage: "memorychip")
-                            .font(.caption)
-                            .foregroundStyle(.white.opacity(0.85))
-                        if entry.isMoE {
-                            Label("MoE", systemImage: "square.grid.3x3.fill")
-                                .font(.caption)
-                                .foregroundStyle(.white.opacity(0.85))
-                        }
-                        Label(entry.quantization, systemImage: "slider.horizontal.3")
-                            .font(.caption)
-                            .foregroundStyle(.white.opacity(0.85))
-                    }
-                }
-            }
-            .padding(16)
-        }
-        .frame(maxWidth: .infinity)
-        .frame(height: 130)
-        .shadow(color: .teal.opacity(0.3), radius: 8, y: 4)
-    }
-
+extension ModelsView {
     @ViewBuilder
-    private var stateBadge: some View {
-        switch state {
-        case .ready(_):
-            Label("Ready", systemImage: "checkmark.circle.fill")
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.white)
-                .padding(.horizontal, 10)
-                .padding(.vertical, 4)
-                .background(.white.opacity(0.2), in: Capsule())
-        case .generating:
-            Label("Generating", systemImage: "waveform")
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.white)
-                .padding(.horizontal, 10)
-                .padding(.vertical, 4)
-                .background(.white.opacity(0.2), in: Capsule())
-        default:
-            EmptyView()
-        }
+    var activeModelCard: some View {
+        ActiveModelCardView()
+            .environmentObject(engine)
     }
 }
-
-// MARK: — Active Model Card (handles all ModelState cases)
 
 private struct ActiveModelCardView: View {
     @EnvironmentObject private var engine: InferenceEngine
@@ -271,62 +238,170 @@ private struct ActiveModelCardView: View {
 
     private var loadingCard: some View {
         HStack(spacing: 12) {
-            ProgressView().controlSize(.regular)
+            ProgressView().controlSize(.regular).tint(SwiftLMTheme.accent)
             VStack(alignment: .leading, spacing: 2) {
                 Text("Loading model…")
                     .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(SwiftLMTheme.textPrimary)
                 Text("Initializing Metal GPU")
-                    .font(.caption).foregroundStyle(.secondary)
+                    .font(.caption)
+                    .foregroundStyle(SwiftLMTheme.textSecondary)
             }
             Spacer()
         }
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .glassCard(cornerRadius: SwiftLMTheme.radiusLarge)
     }
 
     private func downloadingCard(progress: Double, speed: String) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 10) {
             HStack {
                 Image(systemName: "arrow.down.circle.fill")
-                    .foregroundStyle(.blue)
+                    .foregroundStyle(SwiftLMTheme.accent)
                 Text("Downloading model…")
                     .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(SwiftLMTheme.textPrimary)
                 Spacer()
                 Text("\(Int(progress * 100))%")
                     .font(.caption.monospacedDigit())
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(SwiftLMTheme.textSecondary)
             }
-            ProgressView(value: progress).tint(.blue)
-            Text(speed).font(.caption).foregroundStyle(.secondary)
+            ProgressView(value: progress).tint(SwiftLMTheme.accent)
+            Text(speed)
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(SwiftLMTheme.textSecondary)
         }
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .glassCard(cornerRadius: SwiftLMTheme.radiusLarge)
     }
 
     private var idleCard: some View {
         HStack(spacing: 12) {
-            Image(systemName: "cpu")
-                .font(.title2)
-                .foregroundStyle(.secondary)
-            VStack(alignment: .leading, spacing: 2) {
+            ZStack {
+                Circle()
+                    .fill(SwiftLMTheme.heroGradient)
+                    .frame(width: 46, height: 46)
+                    .shadow(color: SwiftLMTheme.accent.opacity(0.30), radius: 8)
+                Image(systemName: "bolt.fill")
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(.white)
+            }
+            VStack(alignment: .leading, spacing: 3) {
                 Text("No model loaded")
                     .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(SwiftLMTheme.textPrimary)
                 Text("Select a model below to start chatting")
-                    .font(.caption).foregroundStyle(.secondary)
+                    .font(.caption)
+                    .foregroundStyle(SwiftLMTheme.textSecondary)
             }
             Spacer()
         }
         .padding()
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .glassCard(cornerRadius: SwiftLMTheme.radiusLarge)
     }
 }
 
-// Workaround: top-level computed property for activeModelCard
-extension ModelsView {
+private struct ActiveModelHeroCard: View {
+    let modelId: String
+    let entry: ModelEntry?
+    let state: ModelState
+
+    var body: some View {
+        ZStack(alignment: .bottomLeading) {
+            // Dark mesh gradient background
+            RoundedRectangle(cornerRadius: SwiftLMTheme.radiusLarge)
+                .fill(SwiftLMTheme.heroGradient)
+
+            // Glow orb
+            Circle()
+                .fill(SwiftLMTheme.accent.opacity(0.18))
+                .frame(width: 120, height: 120)
+                .blur(radius: 30)
+                .offset(x: 60, y: -20)
+
+            // Border
+            RoundedRectangle(cornerRadius: SwiftLMTheme.radiusLarge)
+                .strokeBorder(
+                    LinearGradient(
+                        colors: [SwiftLMTheme.accent.opacity(0.40), Color.white.opacity(0.05)],
+                        startPoint: .topLeading, endPoint: .bottomTrailing
+                    ),
+                    lineWidth: 1
+                )
+
+            // Content
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Active Model")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.white.opacity(0.65))
+                    Spacer()
+                    stateBadge
+                }
+
+                Text(entry?.displayName ?? modelId.components(separatedBy: "/").last ?? modelId)
+                    .font(.title2.weight(.bold))
+                    .foregroundStyle(.white)
+                    .lineLimit(2)
+
+                HStack(spacing: 10) {
+                    if let entry {
+                        heroChip(String(format: "%.1f GB RAM", entry.ramRequiredGB), icon: "memorychip")
+                        if entry.isMoE {
+                            heroChip("MoE", icon: "square.grid.3x3.fill")
+                        }
+                        heroChip(entry.quantization, icon: "slider.horizontal.3")
+                    }
+                }
+            }
+            .padding(16)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 140)
+        .shadow(
+            color: SwiftLMTheme.shadowCard.color,
+            radius: SwiftLMTheme.shadowCard.radius,
+            x: SwiftLMTheme.shadowCard.x,
+            y: SwiftLMTheme.shadowCard.y
+        )
+    }
+
+    private func heroChip(_ label: String, icon: String) -> some View {
+        Label(label, systemImage: icon)
+            .font(.caption)
+            .foregroundStyle(.white.opacity(0.75))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(.white.opacity(0.12), in: Capsule())
+    }
+
     @ViewBuilder
-    var activeModelCard: some View {
-        ActiveModelCardView()
-            .environmentObject(engine)
+    private var stateBadge: some View {
+        switch state {
+        case .ready:
+            badgeView("Ready", icon: "checkmark.circle.fill", color: SwiftLMTheme.success)
+        case .generating:
+            HStack(spacing: 4) {
+                GeneratingDots()
+                Text("Generating")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.white)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .background(.white.opacity(0.15), in: Capsule())
+        default:
+            EmptyView()
+        }
+    }
+
+    private func badgeView(_ label: String, icon: String, color: Color) -> some View {
+        Label(label, systemImage: icon)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(color)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .background(color.opacity(0.18), in: Capsule())
     }
 }
 
@@ -341,39 +416,41 @@ private struct DownloadProgressCard: View {
             HStack(spacing: 10) {
                 ZStack {
                     Circle()
-                        .stroke(Color.blue.opacity(0.15), lineWidth: 3)
+                        .stroke(SwiftLMTheme.accent.opacity(0.15), lineWidth: 3)
                     Circle()
                         .trim(from: 0, to: progress.fractionCompleted)
-                        .stroke(Color.blue, style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                        .stroke(SwiftLMTheme.avatarGradient,
+                                style: StrokeStyle(lineWidth: 3, lineCap: .round))
                         .rotationEffect(.degrees(-90))
                         .animation(.linear(duration: 0.3), value: progress.fractionCompleted)
                 }
                 .frame(width: 32, height: 32)
 
-                VStack(alignment: .leading, spacing: 1) {
+                VStack(alignment: .leading, spacing: 2) {
                     Text(modelId.components(separatedBy: "/").last ?? modelId)
                         .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(SwiftLMTheme.textPrimary)
                         .lineLimit(1)
                     HStack(spacing: 6) {
                         Text("\(Int(progress.fractionCompleted * 100))%")
                             .font(.caption.monospacedDigit())
-                            .foregroundStyle(.blue)
+                            .foregroundStyle(SwiftLMTheme.accent)
                         if let speed = progress.speedMBps {
                             Text("·")
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(SwiftLMTheme.textTertiary).font(.caption)
                             Text(String(format: "%.1f MB/s", speed))
                                 .font(.caption.monospacedDigit())
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(SwiftLMTheme.textSecondary)
                         }
                     }
                 }
                 Spacer()
             }
             ProgressView(value: progress.fractionCompleted)
-                .tint(.blue)
+                .tint(SwiftLMTheme.accent)
         }
-        .padding(12)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .padding(14)
+        .glassCard(cornerRadius: SwiftLMTheme.radiusMedium)
     }
 }
 
@@ -391,52 +468,45 @@ private struct DownloadedModelRow: View {
             if !isActive { onLoad() }
         } label: {
             HStack(spacing: 12) {
-                // Icon
                 ZStack {
                     RoundedRectangle(cornerRadius: 10)
-                        .fill(isActive ? Color.teal : Color.secondary.opacity(0.15))
+                        .fill(isActive ? AnyShapeStyle(SwiftLMTheme.userBubbleGradient) : AnyShapeStyle(SwiftLMTheme.surface))
                         .frame(width: 44, height: 44)
                     Image(systemName: entry?.isMoE == true ? "square.grid.3x3.fill" : "brain")
                         .font(.body)
-                        .foregroundStyle(isActive ? .white : .primary)
+                        .foregroundStyle(isActive ? .white : SwiftLMTheme.textSecondary)
                 }
+                .shadow(color: isActive ? SwiftLMTheme.accent.opacity(0.30) : .clear, radius: 6)
 
                 VStack(alignment: .leading, spacing: 3) {
                     HStack(spacing: 6) {
                         Text(entry?.displayName ?? downloaded.id.components(separatedBy: "/").last ?? downloaded.id)
                             .font(.subheadline.weight(.semibold))
-                            .foregroundStyle(.primary)
+                            .foregroundStyle(SwiftLMTheme.textPrimary)
                         if isActive {
-                            Text("IN USE")
-                                .font(.system(size: 9, weight: .bold))
-                                .padding(.horizontal, 5).padding(.vertical, 2)
-                                .background(Color.teal.opacity(0.15), in: Capsule())
-                                .foregroundStyle(.teal)
+                            ThemedBadge(text: "IN USE", color: SwiftLMTheme.accent)
                         }
                     }
                     HStack(spacing: 6) {
                         Text(downloaded.displaySize)
-                            .font(.caption).foregroundStyle(.secondary)
+                            .font(.caption)
+                            .foregroundStyle(SwiftLMTheme.textSecondary)
                         if let entry {
-                            Text("·").foregroundStyle(.tertiary).font(.caption)
-                            Text(entry.quantization).font(.caption).foregroundStyle(.secondary)
+                            Text("·").foregroundStyle(SwiftLMTheme.textTertiary).font(.caption)
+                            Text(entry.quantization)
+                                .font(.caption)
+                                .foregroundStyle(SwiftLMTheme.textSecondary)
                         }
                     }
                 }
 
                 Spacer()
 
-                if isActive {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundStyle(.teal)
-                        .font(.title3)
-                } else {
-                    Image(systemName: "arrow.right.circle")
-                        .foregroundStyle(.secondary)
-                        .font(.title3)
-                }
+                Image(systemName: isActive ? "checkmark.circle.fill" : "arrow.right.circle")
+                    .foregroundStyle(isActive ? SwiftLMTheme.accent : SwiftLMTheme.textTertiary)
+                    .font(.title3)
             }
-            .padding(.vertical, 10)
+            .padding(.vertical, 12)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -455,66 +525,83 @@ private struct CatalogCard: View {
     let fitStatus: ModelCatalog.FitStatus
     let onTap: () -> Void
 
+    @State private var tapped = false
+
     var body: some View {
-        Button(action: onTap) {
+        Button {
+            withAnimation(SwiftLMTheme.quickSpring) { tapped = true }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                tapped = false
+                onTap()
+            }
+        } label: {
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
                     Image(systemName: model.isMoE ? "square.grid.3x3.fill" : "brain")
                         .font(.title3)
                         .foregroundStyle(fitColor)
                     Spacer()
-                    fitBadge
+                    fitBadgeIcon
                 }
-
                 Spacer()
-
                 Text(model.displayName)
                     .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(.primary)
+                    .foregroundStyle(SwiftLMTheme.textPrimary)
                     .lineLimit(2)
                     .multilineTextAlignment(.leading)
 
                 Text(String(format: "~%.0f GB RAM", model.ramRequiredGB))
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(SwiftLMTheme.textSecondary)
 
-                Label("Download", systemImage: "arrow.down.circle")
-                    .font(.caption.weight(.medium))
-                    .foregroundStyle(fitColor)
-                    .padding(.top, 2)
+                HStack(spacing: 4) {
+                    Image(systemName: "arrow.down.circle")
+                        .font(.caption)
+                    Text("Download")
+                        .font(.caption.weight(.medium))
+                }
+                .foregroundStyle(fitColor)
+                .padding(.top, 2)
             }
             .padding(14)
-            .frame(width: 150, height: 160)
-            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14))
+            .frame(width: 150, height: 165)
+            .background(SwiftLMTheme.surface.opacity(0.70))
+            .clipShape(RoundedRectangle(cornerRadius: SwiftLMTheme.radiusMedium))
+            .overlay(
+                RoundedRectangle(cornerRadius: SwiftLMTheme.radiusMedium)
+                    .strokeBorder(fitColor.opacity(tapped ? 0.60 : 0.18), lineWidth: 1)
+            )
+            .scaleEffect(tapped ? 0.96 : 1.0)
+            .shadow(color: fitColor.opacity(tapped ? 0.30 : 0.08), radius: 8, y: 4)
         }
         .buttonStyle(.plain)
     }
 
     private var fitColor: Color {
         switch fitStatus {
-        case .fits: return .blue
-        case .tight: return .orange
-        case .requiresFlash: return .indigo
-        case .tooLarge: return .red
+        case .fits:          return SwiftLMTheme.accent
+        case .tight:         return SwiftLMTheme.warning
+        case .requiresFlash: return Color.indigo
+        case .tooLarge:      return SwiftLMTheme.error
         }
     }
 
     @ViewBuilder
-    private var fitBadge: some View {
+    private var fitBadgeIcon: some View {
         switch fitStatus {
         case .fits:
-            Image(systemName: "checkmark.circle.fill").foregroundStyle(.green).font(.caption)
+            Image(systemName: "checkmark.circle.fill").foregroundStyle(SwiftLMTheme.success).font(.caption)
         case .tight:
-            Image(systemName: "exclamationmark.circle").foregroundStyle(.orange).font(.caption)
+            Image(systemName: "exclamationmark.circle").foregroundStyle(SwiftLMTheme.warning).font(.caption)
         case .requiresFlash:
-            Image(systemName: "externaldrive.badge.wifi").foregroundStyle(.indigo).font(.caption)
+            Image(systemName: "externaldrive.badge.wifi").foregroundStyle(Color.indigo).font(.caption)
         case .tooLarge:
-            Image(systemName: "xmark.circle").foregroundStyle(.red).font(.caption)
+            Image(systemName: "xmark.circle").foregroundStyle(SwiftLMTheme.error).font(.caption)
         }
     }
 }
 
-// MARK: — Catalog List Row (vertical list)
+// MARK: — Catalog List Row
 
 private struct CatalogListRow: View {
     let model: ModelEntry
@@ -526,7 +613,7 @@ private struct CatalogListRow: View {
             HStack(spacing: 12) {
                 ZStack {
                     RoundedRectangle(cornerRadius: 8)
-                        .fill(fitColor.opacity(0.12))
+                        .fill(fitColor.opacity(0.14))
                         .frame(width: 40, height: 40)
                     Image(systemName: model.isMoE ? "square.grid.3x3.fill" : "brain")
                         .font(.callout)
@@ -537,18 +624,14 @@ private struct CatalogListRow: View {
                     HStack(spacing: 6) {
                         Text(model.displayName)
                             .font(.subheadline.weight(.semibold))
-                            .foregroundStyle(.primary)
+                            .foregroundStyle(SwiftLMTheme.textPrimary)
                         if let badge = model.badge {
-                            Text(badge)
-                                .font(.system(size: 9, weight: .bold))
-                                .padding(.horizontal, 5).padding(.vertical, 2)
-                                .background(Color.blue.opacity(0.12), in: Capsule())
-                                .foregroundStyle(.blue)
+                            ThemedBadge(text: badge, color: SwiftLMTheme.accent)
                         }
                     }
                     Text("\(model.parameterSize) · \(model.quantization) · ~\(String(format: "%.0f GB", model.ramRequiredGB)) RAM")
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(SwiftLMTheme.textSecondary)
                 }
 
                 Spacer()
@@ -563,10 +646,10 @@ private struct CatalogListRow: View {
 
     private var fitColor: Color {
         switch fitStatus {
-        case .fits: return .blue
-        case .tight: return .orange
-        case .requiresFlash: return .indigo
-        case .tooLarge: return .red
+        case .fits:          return SwiftLMTheme.accent
+        case .tight:         return SwiftLMTheme.warning
+        case .requiresFlash: return Color.indigo
+        case .tooLarge:      return SwiftLMTheme.error
         }
     }
 
@@ -575,21 +658,21 @@ private struct CatalogListRow: View {
         switch fitStatus {
         case .fits:
             Image(systemName: "arrow.down.circle")
-                .foregroundStyle(.blue).font(.title3)
+                .foregroundStyle(SwiftLMTheme.accent).font(.title3)
         case .tight:
             Image(systemName: "arrow.down.circle")
-                .foregroundStyle(.orange).font(.title3)
+                .foregroundStyle(SwiftLMTheme.warning).font(.title3)
         case .requiresFlash:
             Image(systemName: "externaldrive.badge.wifi")
-                .foregroundStyle(.indigo).font(.title3)
+                .foregroundStyle(Color.indigo).font(.title3)
         case .tooLarge:
             Image(systemName: "xmark.circle")
-                .foregroundStyle(.red).font(.title3)
+                .foregroundStyle(SwiftLMTheme.error).font(.title3)
         }
     }
 }
 
-// MARK: — HF Search Sheet (extracted from ModelPickerView)
+// MARK: — HF Search Sheet
 
 private struct HFSearchSheet: View {
     @EnvironmentObject private var engine: InferenceEngine
@@ -598,15 +681,21 @@ private struct HFSearchSheet: View {
 
     var body: some View {
         NavigationStack {
-            HFSearchTab(onSelect: { id in
-                onSelect(id)
-                dismiss()
-            })
+            ZStack {
+                SwiftLMTheme.background.ignoresSafeArea()
+                HFSearchTab(onSelect: { id in
+                    onSelect(id)
+                    dismiss()
+                })
+            }
             .navigationTitle("Search HuggingFace")
+            #if os(iOS)
             .navigationBarTitleDisplayMode(.inline)
+            #endif
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
+                        .foregroundStyle(SwiftLMTheme.accent)
                 }
             }
         }

--- a/SwiftLMChat/SwiftLMChat/Views/RootView.swift
+++ b/SwiftLMChat/SwiftLMChat/Views/RootView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct RootView: View {
     @EnvironmentObject private var engine: InferenceEngine
+    @EnvironmentObject private var appearance: AppearanceStore
     @StateObject private var viewModel = ChatViewModel()
 
     // iOS: tab selection
@@ -27,6 +28,7 @@ struct RootView: View {
                 }
                 .sheet(isPresented: $showSettings) {
                     SettingsView(viewModel: viewModel)
+                        .environmentObject(appearance)
                 }
                 .onReceive(NotificationCenter.default.publisher(for: .showModelPicker)) { _ in
                     showModelPicker = true
@@ -50,7 +52,7 @@ struct RootView: View {
     #if os(iOS)
     private var iOSTabView: some View {
         TabView(selection: $selectedTab) {
-            // ── Chat Tab ────────────────────────────────────────────────
+            // ── Chat Tab ──────────────────────────────────────────────────
             NavigationStack {
                 ChatView(viewModel: viewModel)
                     .environmentObject(engine)
@@ -62,7 +64,7 @@ struct RootView: View {
             }
             .tag(Tab.chat)
 
-            // ── Models Tab ──────────────────────────────────────────────
+            // ── Models Tab ────────────────────────────────────────────────
             NavigationStack {
                 ModelsView(viewModel: viewModel)
                     .environmentObject(engine)
@@ -71,17 +73,21 @@ struct RootView: View {
                 Label("Models", systemImage: selectedTab == .models ? "cpu.fill" : "cpu")
             }
             .tag(Tab.models)
-            .badge(engine.downloadManager.activeDownloads.isEmpty ? 0 : engine.downloadManager.activeDownloads.count)
+            .badge(engine.downloadManager.activeDownloads.isEmpty
+                   ? 0
+                   : engine.downloadManager.activeDownloads.count)
 
-            // ── Settings Tab ────────────────────────────────────────────
+            // ── Settings Tab ──────────────────────────────────────────────
             NavigationStack {
                 SettingsView(viewModel: viewModel, isTab: true)
+                    .environmentObject(appearance)
             }
             .tabItem {
                 Label("Settings", systemImage: selectedTab == .settings ? "gearshape.fill" : "gearshape")
             }
             .tag(Tab.settings)
         }
+        .tint(SwiftLMTheme.accent)
         // Navigate to Models tab when a model load is requested from chat
         .onReceive(NotificationCenter.default.publisher(for: .showModelPicker)) { _ in
             selectedTab = .models
@@ -95,31 +101,94 @@ struct RootView: View {
     private var macOSLayout: some View {
         NavigationSplitView {
             VStack(alignment: .leading, spacing: 0) {
-                modelStatusView
+                // ── Branded sidebar header ────────────────────────────────
+                sidebarHeader
                 Divider()
+                    .background(SwiftLMTheme.divider)
+
+                // ── Engine status ─────────────────────────────────────────
+                engineStatusSection
+                Divider()
+                    .background(SwiftLMTheme.divider)
+
+                // ── Actions list ──────────────────────────────────────────
                 List {
-                    Label("New Chat", systemImage: "plus.bubble")
-                        .onTapGesture { viewModel.newConversation() }
+                    Section("Conversations") {
+                        Button {
+                            viewModel.newConversation()
+                        } label: {
+                            Label("New Chat", systemImage: "plus.bubble")
+                                .foregroundStyle(SwiftLMTheme.accent)
+                        }
+                        .buttonStyle(.plain)
+                    }
                 }
                 .listStyle(.sidebar)
+                .scrollContentBackground(.hidden)
+                .background(SwiftLMTheme.background)
             }
-            .frame(minWidth: 200)
+            .frame(minWidth: 220)
+            .background(SwiftLMTheme.background)
         } detail: {
-            ChatView(viewModel: viewModel, showSettings: $showSettings, showModelPicker: $showModelPicker)
+            ChatView(
+                viewModel: viewModel,
+                showSettings: $showSettings,
+                showModelPicker: $showModelPicker
+            )
+            .background(SwiftLMTheme.background)
         }
         .navigationTitle("")
     }
 
-    private var modelStatusView: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack {
-                Image(systemName: "cpu").foregroundStyle(.secondary)
-                Text("SwiftLM").font(.headline)
-                Spacer()
+    // Branded header — bolt icon + SwiftLM wordmark + version chip
+    private var sidebarHeader: some View {
+        HStack(spacing: 10) {
+            ZStack {
+                Circle()
+                    .fill(SwiftLMTheme.heroGradient)
+                    .frame(width: 32, height: 32)
+                Image(systemName: "bolt.fill")
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundStyle(.white)
             }
-            engineStateView
+            .shadow(color: SwiftLMTheme.accent.opacity(0.40), radius: 6)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text("SwiftLM")
+                    .font(.system(.subheadline, weight: .bold))
+                    .foregroundStyle(SwiftLMTheme.textPrimary)
+                Text("Chat")
+                    .font(.caption2)
+                    .foregroundStyle(SwiftLMTheme.textTertiary)
+            }
+
+            Spacer()
+
+            Text("v1.0")
+                .font(.system(size: 9, weight: .bold))
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(SwiftLMTheme.accent.opacity(0.18), in: Capsule())
+                .foregroundStyle(SwiftLMTheme.accent)
         }
-        .padding()
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+    }
+
+    // Engine status row in sidebar
+    private var engineStatusSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Engine")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(SwiftLMTheme.textTertiary)
+                .textCase(.uppercase)
+                .padding(.horizontal, 14)
+                .padding(.top, 10)
+
+            engineStateView
+                .padding(.horizontal, 14)
+                .padding(.bottom, 10)
+        }
     }
 
     @ViewBuilder
@@ -127,25 +196,55 @@ struct RootView: View {
         switch engine.state {
         case .idle:
             Button("Load Model") { showModelPicker = true }
-                .buttonStyle(.borderedProminent).controlSize(.small)
+                .buttonStyle(.borderedProminent)
+                .tint(SwiftLMTheme.accent)
+                .controlSize(.small)
+
         case .loading:
-            Label("Loading…", systemImage: "arrow.2.circlepath")
-                .font(.caption).foregroundStyle(.secondary)
-        case .downloading(let progress, let speed):
-            VStack(alignment: .leading, spacing: 2) {
-                ProgressView(value: progress)
-                Text("\(Int(progress * 100))% · \(speed)")
-                    .font(.caption2).foregroundStyle(.secondary)
+            HStack(spacing: 6) {
+                ProgressView().controlSize(.mini).tint(SwiftLMTheme.accent)
+                Text("Loading…")
+                    .font(.caption)
+                    .foregroundStyle(SwiftLMTheme.textSecondary)
             }
+
+        case .downloading(let progress, let speed):
+            VStack(alignment: .leading, spacing: 4) {
+                ProgressView(value: progress).tint(SwiftLMTheme.accent)
+                Text("\(Int(progress * 100))% · \(speed)")
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(SwiftLMTheme.textTertiary)
+            }
+
         case .ready(let modelId):
-            Label(modelId.components(separatedBy: "/").last ?? modelId, systemImage: "checkmark.circle.fill")
-                .font(.caption).foregroundStyle(.green).lineLimit(1)
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(SwiftLMTheme.success)
+                    .frame(width: 7, height: 7)
+                Text(modelId.components(separatedBy: "/").last ?? modelId)
+                    .font(.caption)
+                    .foregroundStyle(SwiftLMTheme.textSecondary)
+                    .lineLimit(1)
+            }
+
         case .generating:
-            Label("Generating…", systemImage: "ellipsis.bubble")
-                .font(.caption).foregroundStyle(.blue)
+            HStack(spacing: 6) {
+                GeneratingDots()
+                Text("Generating…")
+                    .font(.caption)
+                    .foregroundStyle(SwiftLMTheme.textSecondary)
+            }
+
         case .error(let msg):
-            Label(msg, systemImage: "exclamationmark.triangle")
-                .font(.caption).foregroundStyle(.red).lineLimit(2)
+            HStack(spacing: 6) {
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(SwiftLMTheme.error)
+                Text(msg)
+                    .font(.caption)
+                    .foregroundStyle(SwiftLMTheme.error)
+                    .lineLimit(2)
+            }
         }
     }
     #endif

--- a/SwiftLMChat/SwiftLMChat/Views/SettingsView.swift
+++ b/SwiftLMChat/SwiftLMChat/Views/SettingsView.swift
@@ -3,149 +3,283 @@ import SwiftUI
 
 struct SettingsView: View {
     @ObservedObject var viewModel: ChatViewModel
+    @EnvironmentObject private var appearance: AppearanceStore
     @Environment(\.dismiss) private var dismiss
 
-    /// When true, the view is embedded as a tab (no Done button needed on iOS)
+    /// When true, the view is embedded as a tab (no Done button on iOS)
     var isTab: Bool = false
 
+    // iOS-specific: performance mode toggle (read from UserDefaults)
+    @AppStorage("swiftlm.performanceMode") private var performanceMode: Bool = false
+
+    private var ramGB: Double {
+        Double(ProcessInfo.processInfo.physicalMemory) / (1024 * 1024 * 1024)
+    }
+
     var body: some View {
-        Form {
-            // ── Generation ────────────────────────────────────────────────
-            Section {
-                // Temperature
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack {
-                        Label("Temperature", systemImage: "thermometer.medium")
-                        Spacer()
-                        Text(String(format: "%.2f", viewModel.config.temperature))
-                            .foregroundStyle(.secondary)
-                            .monospacedDigit()
-                            .font(.callout)
-                    }
-                    Slider(value: Binding(
-                        get: { Double(viewModel.config.temperature) },
-                        set: { viewModel.config.temperature = Float($0) }
-                    ), in: 0...2, step: 0.05)
-                    .tint(.orange)
-                    Text("Higher = more creative, lower = more focused")
-                        .font(.caption2).foregroundStyle(.secondary)
-                }
-                .padding(.vertical, 2)
+        ZStack {
+            SwiftLMTheme.background.ignoresSafeArea()
 
-                // Max Tokens
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack {
-                        Label("Max Tokens", systemImage: "text.word.spacing")
-                        Spacer()
-                        Text("\(viewModel.config.maxTokens)")
-                            .foregroundStyle(.secondary)
-                            .monospacedDigit()
-                            .font(.callout)
-                    }
-                    Slider(value: Binding(
-                        get: { Double(viewModel.config.maxTokens) },
-                        set: { viewModel.config.maxTokens = Int($0) }
-                    ), in: 128...8192, step: 128)
-                    .tint(.blue)
+            Form {
+                // ── Generation ────────────────────────────────────────────────
+                Section {
+                    temperatureRow
+                    maxTokensRow
+                    topPRow
+                } header: {
+                    sectionLabel("Generation", icon: "slider.horizontal.3")
                 }
-                .padding(.vertical, 2)
 
-                // Top P
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack {
-                        Label("Top P", systemImage: "chart.bar.xaxis")
-                        Spacer()
-                        Text(String(format: "%.2f", viewModel.config.topP))
-                            .foregroundStyle(.secondary)
-                            .monospacedDigit()
-                            .font(.callout)
-                    }
-                    Slider(value: Binding(
-                        get: { Double(viewModel.config.topP) },
-                        set: { viewModel.config.topP = Float($0) }
-                    ), in: 0...1, step: 0.05)
-                    .tint(.purple)
+                // ── Advanced ──────────────────────────────────────────────────
+                Section {
+                    thinkingToggle
+                } header: {
+                    sectionLabel("Advanced", icon: "gearshape.2")
                 }
-                .padding(.vertical, 2)
-            } header: {
-                Label("Generation", systemImage: "slider.horizontal.3")
-            }
 
-            // ── Advanced ──────────────────────────────────────────────────
-            Section {
-                Toggle(isOn: Binding(
-                    get: { viewModel.config.enableThinking },
-                    set: { viewModel.config.enableThinking = $0 }
-                )) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Label("Thinking Mode", systemImage: "brain.head.profile")
-                        Text("Step-by-step reasoning for Qwen3, DeepSeek-R1, and compatible models")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                // ── Appearance ────────────────────────────────────────────────
+                Section {
+                    appearancePicker
+                } header: {
+                    sectionLabel("Appearance", icon: "paintpalette")
+                }
+
+                // ── System Prompt ─────────────────────────────────────────────
+                Section {
+                    TextEditor(text: $viewModel.systemPrompt)
+                        .frame(minHeight: 88)
+                        .font(.callout)
+                        .foregroundStyle(SwiftLMTheme.textPrimary)
+                        .scrollContentBackground(.hidden)
+                        .background(Color.clear)
+                } header: {
+                    sectionLabel("System Prompt", icon: "text.bubble")
+                } footer: {
+                    Text("Injected as the system message before every conversation.")
+                        .font(.caption)
+                        .foregroundStyle(SwiftLMTheme.textTertiary)
+                }
+
+                // ── Performance (iOS-only) ─────────────────────────────────────
+                #if os(iOS)
+                Section {
+                    performanceModeRow
+                    autoOffloadRow
+                } header: {
+                    sectionLabel("Performance", icon: "cpu")
+                } footer: {
+                    Text("Performance Mode loosens the RAM budget from 40% to 55%, allowing larger models on your \(String(format: "%.0f GB", ramGB)) device.")
+                        .font(.caption)
+                        .foregroundStyle(SwiftLMTheme.textTertiary)
+                }
+                #endif
+
+                // ── Reset ─────────────────────────────────────────────────────
+                Section {
+                    Button(role: .destructive) {
+                        viewModel.config = .default
+                        viewModel.systemPrompt = ""
+                    } label: {
+                        HStack {
+                            Spacer()
+                            Label("Reset to Defaults", systemImage: "arrow.counterclockwise")
+                                .foregroundStyle(SwiftLMTheme.error)
+                            Spacer()
+                        }
                     }
                 }
-            } header: {
-                Label("Advanced", systemImage: "gearshape.2")
-            }
 
-            // ── System Prompt ─────────────────────────────────────────────
-            Section {
-                TextEditor(text: $viewModel.systemPrompt)
-                    .frame(minHeight: 88)
-                    .font(.callout)
-            } header: {
-                Label("System Prompt", systemImage: "text.bubble")
-            } footer: {
-                Text("Injected as the system message before every conversation.")
-                    .font(.caption)
-            }
-
-            // ── Reset ─────────────────────────────────────────────────────
-            Section {
-                Button(role: .destructive) {
-                    viewModel.config = .default
-                    viewModel.systemPrompt = ""
-                } label: {
-                    HStack {
-                        Spacer()
-                        Label("Reset to Defaults", systemImage: "arrow.counterclockwise")
-                        Spacer()
-                    }
+                // ── About ─────────────────────────────────────────────────────
+                Section {
+                    aboutRow("SwiftLM Chat", value: "1.0")
+                    aboutRow("Engine", value: "MLX Swift")
+                    aboutRow("Backend", value: "Metal GPU")
+                    aboutRow("Platform", value: {
+                        #if os(iOS)
+                        return "iOS / iPadOS"
+                        #else
+                        return "macOS"
+                        #endif
+                    }())
+                    aboutRow("RAM", value: String(format: "%.0f GB", ramGB))
+                } header: {
+                    sectionLabel("About", icon: "info.circle")
                 }
             }
-
-            // ── About ─────────────────────────────────────────────────────
-            Section {
-                LabeledContent("SwiftLM Chat", value: "1.0")
-                LabeledContent("Engine", value: "MLX Swift")
-                LabeledContent("Backend", value: "Metal GPU")
-                LabeledContent("Platform") {
-                    #if os(iOS)
-                    Text("iOS / iPadOS")
-                        .foregroundStyle(.secondary)
-                    #else
-                    Text("macOS")
-                        .foregroundStyle(.secondary)
-                    #endif
-                }
-            } header: {
-                Label("About", systemImage: "info.circle")
-            }
+            .scrollContentBackground(.hidden)
         }
         .navigationTitle("Settings")
         #if os(iOS)
         .navigationBarTitleDisplayMode(isTab ? .large : .inline)
+        .toolbarBackground(SwiftLMTheme.background.opacity(0.90), for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
         #endif
         .toolbar {
-            // Show Done button only when presented as a sheet (macOS or modal push)
             if !isTab {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") { dismiss() }
+                        .foregroundStyle(SwiftLMTheme.accent)
                 }
             }
         }
         #if os(macOS)
-        .frame(width: 420, height: 600)
+        .frame(width: 440, height: 640)
         #endif
+    }
+
+    // MARK: — Row Helpers
+
+    private var temperatureRow: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Label("Temperature", systemImage: "thermometer.medium")
+                    .foregroundStyle(SwiftLMTheme.textPrimary)
+                Spacer()
+                Text(String(format: "%.2f", viewModel.config.temperature))
+                    .foregroundStyle(SwiftLMTheme.textSecondary)
+                    .monospacedDigit()
+                    .font(.callout)
+            }
+            Slider(value: Binding(
+                get: { Double(viewModel.config.temperature) },
+                set: { viewModel.config.temperature = Float($0) }
+            ), in: 0...2, step: 0.05)
+            .tint(SwiftLMTheme.warning)
+            Text("Higher = more creative, lower = more focused")
+                .font(.caption2)
+                .foregroundStyle(SwiftLMTheme.textTertiary)
+        }
+        .padding(.vertical, 2)
+    }
+
+    private var maxTokensRow: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Label("Max Tokens", systemImage: "text.word.spacing")
+                    .foregroundStyle(SwiftLMTheme.textPrimary)
+                Spacer()
+                Text("\(viewModel.config.maxTokens)")
+                    .foregroundStyle(SwiftLMTheme.textSecondary)
+                    .monospacedDigit()
+                    .font(.callout)
+            }
+            Slider(value: Binding(
+                get: { Double(viewModel.config.maxTokens) },
+                set: { viewModel.config.maxTokens = Int($0) }
+            ), in: 128...8192, step: 128)
+            .tint(SwiftLMTheme.accent)
+        }
+        .padding(.vertical, 2)
+    }
+
+    private var topPRow: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Label("Top P", systemImage: "chart.bar.xaxis")
+                    .foregroundStyle(SwiftLMTheme.textPrimary)
+                Spacer()
+                Text(String(format: "%.2f", viewModel.config.topP))
+                    .foregroundStyle(SwiftLMTheme.textSecondary)
+                    .monospacedDigit()
+                    .font(.callout)
+            }
+            Slider(value: Binding(
+                get: { Double(viewModel.config.topP) },
+                set: { viewModel.config.topP = Float($0) }
+            ), in: 0...1, step: 0.05)
+            .tint(SwiftLMTheme.accentSecondary)
+        }
+        .padding(.vertical, 2)
+    }
+
+    private var thinkingToggle: some View {
+        Toggle(isOn: Binding(
+            get: { viewModel.config.enableThinking },
+            set: { viewModel.config.enableThinking = $0 }
+        )) {
+            VStack(alignment: .leading, spacing: 2) {
+                Label("Thinking Mode", systemImage: "brain.head.profile")
+                    .foregroundStyle(SwiftLMTheme.textPrimary)
+                Text("Step-by-step reasoning for Qwen3, DeepSeek-R1, and compatible models")
+                    .font(.caption)
+                    .foregroundStyle(SwiftLMTheme.textTertiary)
+            }
+        }
+        .tint(SwiftLMTheme.accentSecondary)
+    }
+
+    private var appearancePicker: some View {
+        Picker("Color Scheme", selection: $appearance.preference) {
+            HStack {
+                Image(systemName: "moon.fill")
+                Text("Dark")
+            }.tag("dark")
+
+            HStack {
+                Image(systemName: "sun.max.fill")
+                Text("Light")
+            }.tag("light")
+
+            HStack {
+                Image(systemName: "circle.lefthalf.filled")
+                Text("System")
+            }.tag("system")
+        }
+        .pickerStyle(.segmented)
+        .tint(SwiftLMTheme.accent)
+    }
+
+    #if os(iOS)
+    private var performanceModeRow: some View {
+        Toggle(isOn: $performanceMode) {
+            VStack(alignment: .leading, spacing: 2) {
+                Label("Performance Mode", systemImage: "bolt.fill")
+                    .foregroundStyle(SwiftLMTheme.textPrimary)
+                Text("Use 55% RAM budget (vs. 40%) — enables more models on 6 GB devices")
+                    .font(.caption)
+                    .foregroundStyle(SwiftLMTheme.textTertiary)
+            }
+        }
+        .tint(SwiftLMTheme.accent)
+    }
+
+    @State private var tempEngine: InferenceEngine? = nil
+
+    private var autoOffloadRow: some View {
+        // We can't easily get the engine here without prop drilling,
+        // so we persist via UserDefaults and InferenceEngine reads it on next launch.
+        Toggle(isOn: Binding(
+            get: { UserDefaults.standard.bool(forKey: "swiftlm.autoOffload") == false
+                    ? true  // default true
+                    : UserDefaults.standard.bool(forKey: "swiftlm.autoOffload") },
+            set: { UserDefaults.standard.set($0, forKey: "swiftlm.autoOffload") }
+        )) {
+            VStack(alignment: .leading, spacing: 2) {
+                Label("Auto-Unload in Background", systemImage: "iphone.slash")
+                    .foregroundStyle(SwiftLMTheme.textPrimary)
+                Text("Frees GPU memory when the app backgrounds (recommended on iPhone)")
+                    .font(.caption)
+                    .foregroundStyle(SwiftLMTheme.textTertiary)
+            }
+        }
+        .tint(SwiftLMTheme.success)
+    }
+    #endif
+
+    private func aboutRow(_ label: String, value: String) -> some View {
+        HStack {
+            Text(label)
+                .foregroundStyle(SwiftLMTheme.textPrimary)
+            Spacer()
+            Text(value)
+                .foregroundStyle(SwiftLMTheme.textSecondary)
+        }
+    }
+
+    private func sectionLabel(_ title: String, icon: String) -> some View {
+        Label(title, systemImage: icon)
+            .foregroundStyle(SwiftLMTheme.textTertiary)
+            .font(.footnote.weight(.semibold))
+            .textCase(.uppercase)
     }
 }

--- a/SwiftLMChat/generate_xcodeproj.py
+++ b/SwiftLMChat/generate_xcodeproj.py
@@ -52,6 +52,7 @@ ASSETS_BF     = uid()
 # ── App source files (relative to SwiftLMChat/)
 app_sources = [
     ("SwiftLMChat/SwiftLMChatApp.swift",          uid(), uid()),
+    ("SwiftLMChat/Theme.swift",                   uid(), uid()),
     ("SwiftLMChat/Views/RootView.swift",           uid(), uid()),
     ("SwiftLMChat/Views/ChatView.swift",           uid(), uid()),
     ("SwiftLMChat/Views/MessageBubble.swift",      uid(), uid()),


### PR DESCRIPTION
## SwiftLM Chat — Unified Experience (iPhone 13 Pro 6GB + macOS)

### Design System
- Add Theme.swift: indigo/violet dark palette, glassmorphic surface tokens, gradient definitions, corner radii, animation constants, AvatarView, GeneratingDots, glassCard modifier

### App Entry Point
- AppearanceStore: persists Dark/Light/System preference to UserDefaults
- Default dark mode (.preferredColorScheme), indigo accent + tint

### Chat Interface (ChatView.swift)
- Deep canvas background (SwiftLMTheme.background)
- Animated empty state: bolt brand mark + 'Run any model. Locally. Instantly.'
- Frosted glass input pill with indigo glow ring on focus
- Circular send/stop button with gradient fill (animates between states)
- iOS toolbar: animated GeneratingDots in status capsule during generation

### Message Bubbles (MessageBubble.swift)
- User: indigo→violet gradient bubble with drop shadow
- Assistant: glassmorphic ultraThinMaterial bubble with stroke border
- Avatar: indigo→cyan gradient ring with pulse animation during generation
- Inline blinking cursor (replaces floating overlay)
- Thinking panel: purple-tinted collapsible with animated chevron
- Timestamps hidden by default, revealed on tap

### Models Tab (ModelsView.swift)
- Dark canvas with card-wrapped sections and glass surface
- Hero card: gradient glow orb, chiplet metadata, live state badge
- Catalog cards: spring scale tap animation, color-coded fit borders
- Section headers with horizontal divider rules

### macOS Sidebar (RootView.swift)
- Branded header: bolt icon + SwiftLM wordmark + v1.0 version chip
- GeneratingDots animation in engine status section
- Full dark background throughout split view

### Settings (SettingsView.swift)
- Dark form background, themed sliders and toggles
- Appearance section: Dark/Light/System picker (persisted)
- iOS Performance Mode toggle: loosens RAM budget 40% → 55%
- Auto-Unload in Background toggle
- Live RAM display in About section

### iPhone 13 Pro 6GB Tuning
- ModelDownloadManager: Performance Mode reads swiftlm.performanceMode from UserDefaults → 55% vs 40% RAM budget
  - Conservative (40%): 2.4 GB usable → Qwen3 0.6B/1.7B/4B, Llama 3.2 3B
  - Performance (55%): 3.3 GB usable → unlocks Qwen3 8B, Qwen 2.5 7B
- ModelCatalog: FitStatus thresholds tightened for 6GB (75%/90%), MoE streaming cap lowered from 4x to 3x RAM
- generate_xcodeproj.py: Theme.swift added to build sources

Builds: iOS Simulator ✅  macOS native ✅