### PR TITLE
feat: Add dedicated GitHub Actions Performance Benchmarking workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,82 @@
+name: Performance Benchmark
+
+on:
+  workflow_dispatch:
+    inputs:
+      model_id:
+        description: 'HuggingFace Model ID (must be ungated and fit in 7GB RAM)'
+        required: true
+        default: 'mlx-community/gemma-4-e4b-it-4bit'
+      contexts:
+        description: 'Comma separated context lengths'
+        required: true
+        default: '512,1024,4096'
+      use_ssd_stream:
+        description: 'Enable SSD Expert Streaming'
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  benchmark:
+    runs-on: macos-15
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Metal Toolchain
+        run: xcodebuild -downloadComponent MetalToolchain || true
+
+      - name: Cache Swift packages
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-SwiftLM-v2-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-SwiftLM-v2-
+
+      - name: Resolve dependencies
+        run: swift package resolve
+
+      - name: Build (Release)
+        run: swift build -c release
+
+      - name: Install MLX Metal library & Profiling Dependencies
+        run: |
+          python3 -m venv /tmp/mlx_venv
+          /tmp/mlx_venv/bin/pip install --quiet mlx psutil requests
+          cp /tmp/mlx_venv/lib/python*/site-packages/mlx/lib/mlx.metallib .build/release/
+
+      - name: Cache MLX models
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: mlx-benchmark-model-${{ github.event.inputs.model_id }}
+
+      - name: Run Benchmark Script
+        env:
+          HF_HUB_DOWNLOAD_TIMEOUT: "900"
+        run: |
+          EXTRA_FLAGS=""
+          if [ "${{ github.event.inputs.use_ssd_stream }}" = "true" ]; then
+            EXTRA_FLAGS="--ssd-only"
+            echo "Enabled SSD Streaming mode"
+          fi
+          
+          # Use the environment Python that has the pip dependencies
+          source /tmp/mlx_venv/bin/activate
+          
+          python3 -u scripts/profiling/profile_runner.py \
+            --model "${{ github.event.inputs.model_id }}" \
+            --contexts "${{ github.event.inputs.contexts }}" \
+            $EXTRA_FLAGS \
+            --out "./github-action-benchmark.md"
+
+      - name: Upload Benchmark Results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: ./github-action-benchmark.md
+          retention-days: 7


### PR DESCRIPTION
## Overview
This PR introduces a dedicated, standalone GitHub Actions workflow (`.github/workflows/benchmark.yml`) designed to automatically benchmark Apple MLX generation speeds directly on the CI infrastructure (`macos-15` runner). 

Since Cloud macOS runners typically possess exactly 7 GB of RAM, blindly running the standard benchmark script matrix risks immediate Out-Of-Memory (OOM) `SIGKILL` boundaries. This safe workflow explicitly forces constraints and exposes a configurable matrix to test safe parameter bounds directly from the UI.

## Features
- **UI Triggered (`workflow_dispatch`)**: Fully configurable directly through the GitHub Actions web UI. Does not run implicitly on pushes.
- **Configurable Models**: Supports swapping the `model_id` input immediately prior to run. Defaults to the un-gated `mlx-community/gemma-4-e4b-it-4bit` which safely drops into memory constraints.
- **Context Boundaries**: Tests generation strictly against safe, small context lengths (`"512,1024,4096"`) by default.
- **SSD streaming isolation**: Toggles the `--ssd-only` parameter to explicitly bypass physical limits and test extreme combinations.

## Outputs
- Downloads and manages dependencies (`mlx`, `psutil`, `requests`) inside the GH Action.
- Bundles the final generated `github-action-benchmark.md` table securely as an exported execution artifact on each run.