### PR TITLE
feat: Add support for min-p and top-k sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,9 @@ curl http://localhost:5413/v1/chat/completions \
 | `--audio` | `false` | Enable ALM (audio-language model) mode for audio inputs |
 | `--max-tokens` | `2048` | Max tokens limit per generation |
 | `--prefill-size`| `512`  | Prompt prefill chunk size (micro-batching for long contexts) |
+| `--top-p` | `1.0` | Default top-p nucleus sampling (overridable per-request) |
+| `--top-k` | `50` | Default top-k sampling (0 disables, overridable per-request) |
+| `--min-p` | `0.0` | Default min-p sampling threshold relative to the highest probability token (0 disables) |
 | `--gpu-layers` | `model_default`| Restrict the amount of layers allocated to GPU hardware |
 | `--stream-experts` | `false` | Enable SSD expert streaming for MoE models (10x speedup) |
 | `--turbo-kv` | `false` | Enable TurboQuant 3-bit KV cache compression |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # ⚡️ SwiftLM
 
-> [!WARNING]
-> **DEVELOPMENT NOTE:** The `mlx-swift-lm` SPM dependency is currently locked to the unmerged testing branch `feature/papps-ssd-streaming`. Do not merge to `main` without completing the module integration tests and reverting the URL target constraints.
+[![Awesome MLX](https://img.shields.io/badge/Awesome-MLX-blue?style=flat-square)](https://github.com/raullenchai/awesome-mlx)
 
 A blazingly fast, native Swift inference server that serves [MLX](https://github.com/ml-explore/mlx) models with a strict **OpenAI-compatible API**. 
 

--- a/Sources/MLXInferenceCore/GenerationConfig.swift
+++ b/Sources/MLXInferenceCore/GenerationConfig.swift
@@ -6,6 +6,8 @@ public struct GenerationConfig: Sendable {
     public var maxTokens: Int
     public var temperature: Float
     public var topP: Float
+    public var topK: Int
+    public var minP: Float
     public var repetitionPenalty: Float
     public var seed: UInt64?
     public var enableThinking: Bool
@@ -14,6 +16,8 @@ public struct GenerationConfig: Sendable {
         maxTokens: Int = 2048,
         temperature: Float = 0.6,
         topP: Float = 1.0,
+        topK: Int = 50,
+        minP: Float = 0.0,
         repetitionPenalty: Float = 1.05,
         seed: UInt64? = nil,
         enableThinking: Bool = false
@@ -21,6 +25,8 @@ public struct GenerationConfig: Sendable {
         self.maxTokens = maxTokens
         self.temperature = temperature
         self.topP = topP
+        self.topK = topK
+        self.minP = minP
         self.repetitionPenalty = repetitionPenalty
         self.seed = seed
         self.enableThinking = enableThinking

--- a/Sources/MLXInferenceCore/InferenceEngine.swift
+++ b/Sources/MLXInferenceCore/InferenceEngine.swift
@@ -393,6 +393,8 @@ public final class InferenceEngine: ObservableObject {
                     let mlxMessages = finalMessages
                     var params = GenerateParameters(temperature: config.temperature)
                     params.topP = config.topP
+                    params.topK = config.topK
+                    params.minP = config.minP
                     params.repetitionPenalty = config.repetitionPenalty
                     params.repetitionContextSize = 20
 

--- a/Sources/SwiftLM/Calibrator.swift
+++ b/Sources/SwiftLM/Calibrator.swift
@@ -230,7 +230,10 @@ enum Calibrator {
             let inputTokenCount = lmInput.text.tokens.size
             
             let result: InferenceResult = try await container.perform { context in
-                let generateParams = GenerateParameters(temperature: 0.6)
+                var generateParams = GenerateParameters(temperature: 0.6)
+                generateParams.topP = 1.0
+                generateParams.topK = 50
+                generateParams.minP = 0.0
                 
                 let ttftStart = Date()
                 var firstTokenTime: Date?

--- a/Sources/SwiftLM/Server.swift
+++ b/Sources/SwiftLM/Server.swift
@@ -215,6 +215,12 @@ struct MLXServer: AsyncParsableCommand {
     @Option(name: .long, help: "Default top-p nucleus sampling (overridable per-request)")
     var topP: Float = 1.0
 
+    @Option(name: .long, help: "Default top-k sampling (overridable per-request)")
+    var topK: Int?
+
+    @Option(name: .long, help: "Default min-p sampling (overridable per-request)")
+    var minP: Float?
+
     @Option(name: .long, help: "Repetition penalty factor (overridable per-request)")
     var repeatPenalty: Float?
 
@@ -541,6 +547,8 @@ struct MLXServer: AsyncParsableCommand {
             ctxSize: self.ctxSize,
             temp: self.temp,
             topP: self.topP,
+            topK: self.topK,
+            minP: self.minP,
             repeatPenalty: self.repeatPenalty,
             thinking: self.thinking,
             isVision: isVision,
@@ -567,6 +575,8 @@ struct MLXServer: AsyncParsableCommand {
         let stats = ServerStats()
 
         let ctxSizeStr = config.ctxSize.map { String($0) } ?? "model_default"
+        let topKStr = config.topK.map { String($0) } ?? "disabled"
+        let minPStr = config.minP.map { String($0) } ?? "disabled"
         let penaltyStr = config.repeatPenalty.map { String($0) } ?? "disabled"
         let corsStr = corsOrigin ?? "disabled"
         let memLimitStr = self.memLimit.map { "\($0)MB" } ?? "system_default"
@@ -574,7 +584,7 @@ struct MLXServer: AsyncParsableCommand {
         let thinkingStr = config.thinking ? "enabled" : "disabled"
         let ssdStr = self.streamExperts ? "enabled" : "disabled"
         let turboKVStr = config.turboKV ? "enabled" : "disabled"
-        print("[SwiftLM] Config: ctx_size=\(ctxSizeStr), temp=\(config.temp), top_p=\(config.topP), repeat_penalty=\(penaltyStr), parallel=\(parallelSlots), cors=\(corsStr), mem_limit=\(memLimitStr), auth=\(authStr), thinking=\(thinkingStr), ssd_stream=\(ssdStr), turbo_kv=\(turboKVStr)")
+        print("[SwiftLM] Config: ctx_size=\(ctxSizeStr), temp=\(config.temp), top_p=\(config.topP), top_k=\(topKStr), min_p=\(minPStr), repeat_penalty=\(penaltyStr), parallel=\(parallelSlots), cors=\(corsStr), mem_limit=\(memLimitStr), auth=\(authStr), thinking=\(thinkingStr), ssd_stream=\(ssdStr), turbo_kv=\(turboKVStr)")
 
         // ── Build Hummingbird router ──
         let router = Router()
@@ -811,6 +821,8 @@ struct ServerConfig: Sendable {
     let ctxSize: Int?
     let temp: Float
     let topP: Float
+    let topK: Int?
+    let minP: Float?
     let repeatPenalty: Float?
     let thinking: Bool
     let isVision: Bool
@@ -1023,12 +1035,14 @@ func handleChatCompletion(
     let tokenLimit = chatReq.maxTokens ?? config.maxTokens
     let temperature = chatReq.temperature.map(Float.init) ?? config.temp
     let topP = chatReq.topP.map(Float.init) ?? config.topP
+    let topK = chatReq.topK ?? config.topK ?? 50
+    let minP = chatReq.minP.map(Float.init) ?? config.minP ?? 0.0
     let repeatPenalty = chatReq.repetitionPenalty.map(Float.init) ?? config.repeatPenalty
     let stopSequences = (chatReq.stop ?? []) + ["<end_of_turn>", "<|im_end|>", "<|eot_id|>", "<turn|>", "<|tool_response|>"]
     let includeUsage = chatReq.streamOptions?.includeUsage ?? false
 
     // Log extra sampling params if provided (accepted for API compat, not all are used)
-    if chatReq.topK != nil || chatReq.frequencyPenalty != nil || chatReq.presencePenalty != nil {
+    if chatReq.frequencyPenalty != nil || chatReq.presencePenalty != nil {
         // These are accepted but may not affect generation if MLX doesn't support them
     }
 
@@ -1037,6 +1051,8 @@ func handleChatCompletion(
         maxKVSize: config.ctxSize,
         temperature: temperature,
         topP: topP,
+        topK: topK,
+        minP: minP,
         repetitionPenalty: repeatPenalty,
         prefillStepSize: config.prefillSize
     )
@@ -1682,6 +1698,8 @@ func handleTextCompletion(
     let tokenLimit = compReq.maxTokens ?? config.maxTokens
     let temperature = compReq.temperature.map(Float.init) ?? config.temp
     let topP = compReq.topP.map(Float.init) ?? config.topP
+    let topK = compReq.topK ?? config.topK ?? 50
+    let minP = compReq.minP.map(Float.init) ?? config.minP ?? 0.0
     let repeatPenalty = compReq.repetitionPenalty.map(Float.init) ?? config.repeatPenalty
     let stopSequences = compReq.stop ?? []
 
@@ -1690,6 +1708,8 @@ func handleTextCompletion(
         maxKVSize: config.ctxSize,
         temperature: temperature,
         topP: topP,
+        topK: topK,
+        minP: minP,
         repetitionPenalty: repeatPenalty,
         prefillStepSize: config.prefillSize
     )
@@ -2242,6 +2262,7 @@ struct ChatCompletionRequest: Decodable {
     let temperature: Double?
     let topP: Double?
     let topK: Int?
+    let minP: Double?
     let repetitionPenalty: Double?
     let frequencyPenalty: Double?
     let presencePenalty: Double?
@@ -2260,6 +2281,7 @@ struct ChatCompletionRequest: Decodable {
         case maxTokens = "max_tokens"
         case topP = "top_p"
         case topK = "top_k"
+        case minP = "min_p"
         case repetitionPenalty = "repetition_penalty"
         case frequencyPenalty = "frequency_penalty"
         case presencePenalty = "presence_penalty"
@@ -2277,6 +2299,8 @@ struct TextCompletionRequest: Decodable {
     let maxTokens: Int?
     let temperature: Double?
     let topP: Double?
+    let topK: Int?
+    let minP: Double?
     let repetitionPenalty: Double?
     let stop: [String]?
     let seed: Int?
@@ -2285,6 +2309,8 @@ struct TextCompletionRequest: Decodable {
         case model, prompt, stream, temperature, stop, seed
         case maxTokens = "max_tokens"
         case topP = "top_p"
+        case topK = "top_k"
+        case minP = "min_p"
         case repetitionPenalty = "repetition_penalty"
     }
 }

--- a/tests/test-server.sh
+++ b/tests/test-server.sh
@@ -755,6 +755,21 @@ else
 fi
 
 
+# ── Test 24.5: top_k and min_p per-request override ──────────────────────
+log "Test 24.5: top_k and min_p per-request override"
+
+TOP_MIN_RESP=$(curl -sf -X POST "$URL/v1/chat/completions" \
+    -H "Content-Type: application/json" \
+    -d "{\"model\":\"$MODEL\",\"max_tokens\":10,\"top_k\":40,\"min_p\":0.05,\"messages\":[{\"role\":\"user\",\"content\":\"Say hi.\"}]}")
+
+if echo "$TOP_MIN_RESP" | jq -e '.choices[0].message.content' >/dev/null 2>&1; then
+    CONTENT=$(echo "$TOP_MIN_RESP" | jq -r '.choices[0].message.content')
+    pass "top_k and min_p override: got response: \"$CONTENT\""
+else
+    fail "top_k and min_p override: empty response with top_k=40 and min_p=0.05"
+fi
+
+
 # ── Test 25: Concurrent requests (parallel slot limiter) ─────────────
 log "Test 25: Concurrent requests (2 in parallel)"
 


### PR DESCRIPTION
This PR adds support for min-p and top-k  sampling parameters across the SwiftLM stack.

### Changes:
- **CLI**: Added  and  optional flags to  server.
- **API**: Updated OpenAI-compatible endpoints to accept  and .
- **Inference Core**: Updated  and  to pass these parameters to MLX.
- **Consistency**: Maintained  as an optional parameter to preserve original logging behavior.

Tested with a local build of the  target.