### PR TITLE
ci: switch to SWIFTLM_PR_TOKEN to trigger regression suite on dependency bumps

### DIFF
--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SWIFTLM_PR_TOKEN }}
           commit-message: "chore(deps): bump ${{ github.event.client_payload.source_repo }} to ${{ github.event.client_payload.new_tag }}"
           title: "Update ${{ github.event.client_payload.source_repo }} Dependency to ${{ github.event.client_payload.new_tag }}"
           body: |

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,7 +33,7 @@
       "location" : "https://github.com/SharpAI/mlx-swift.git",
       "state" : {
         "branch" : "main",
-        "revision" : "6d3a11f3439aa21af1e07761778d4a9f466f8a8b"
+        "revision" : "e9a7b5b9f0e60c3a38527b14f778e0edc6ba517f"
       }
     },
     {

--- a/tests/SwiftBuddyTests/VLMRegistryTests.swift
+++ b/tests/SwiftBuddyTests/VLMRegistryTests.swift
@@ -15,6 +15,18 @@ struct MockTokenizer: MLXLMCommon.Tokenizer {
     func applyChatTemplate(messages: [[String: any Sendable]], tools: [[String: any Sendable]]?, additionalContext: [String: any Sendable]?) throws -> [Int] { return [] }
 }
 
+extension ModelTypeRegistry {
+    func testCreateModel(configuration: Data, modelType: String) throws {
+        _ = try self.createModel(configuration: configuration, modelType: modelType)
+    }
+}
+
+extension ProcessorTypeRegistry {
+    func testCreateModel(configuration: Data, processorType: String, tokenizer: any Tokenizer) throws {
+        _ = try self.createModel(configuration: configuration, processorType: processorType, tokenizer: tokenizer)
+    }
+}
+
 final class VLMRegistryTests: XCTestCase {
     
     // Feature 9: VLM model type registry covers all supported types
@@ -30,7 +42,7 @@ final class VLMRegistryTests: XCTestCase {
         
         for type in expectedTypes {
             do {
-                _ = try await registry.createModel(configuration: dummyData, modelType: type)
+                try await registry.testCreateModel(configuration: dummyData, modelType: type)
                 // If it succeeds with dummy data, that's fine, it means the registry works.
             } catch let ModelFactoryError.unsupportedModelType(t) {
                 XCTFail("Registry is missing supported model type: \(t)")
@@ -54,7 +66,7 @@ final class VLMRegistryTests: XCTestCase {
         
         for type in expectedProcessors {
             do {
-                _ = try await registry.createModel(configuration: dummyData, processorType: type, tokenizer: dummyTokenizer)
+                try await registry.testCreateModel(configuration: dummyData, processorType: type, tokenizer: dummyTokenizer)
                 // If it succeeds with dummy data, that's fine, it means the registry works and the config was optional.
             } catch let ModelFactoryError.unsupportedModelType(t) {
                 XCTFail("Registry is missing supported processor type: \(t)")
@@ -69,7 +81,7 @@ final class VLMRegistryTests: XCTestCase {
         let registry = VLMTypeRegistry.shared
         do {
             let data = "{}".data(using: .utf8)!
-            _ = try await registry.createModel(configuration: data, modelType: "nonexistent_model")
+            try await registry.testCreateModel(configuration: data, modelType: "nonexistent_model")
             XCTFail("Should have thrown error")
         } catch ModelFactoryError.unsupportedModelType(let type) {
             XCTAssertEqual(type, "nonexistent_model")


### PR DESCRIPTION
Uses a PAT to bypass GITHUB_TOKEN anti-recursion rules, ensuring the bot-generated dependency bumps trigger a full CI regression check.