### PR TITLE
ci: completely resolve DMG packaging failures

### DIFF
--- a/scripts/build_dmg.sh
+++ b/scripts/build_dmg.sh
@@ -27,7 +27,6 @@ DMG_NAME="SwiftBuddy-macOS-v${VERSION}.dmg"
 
 create-dmg \
   --volname "SwiftBuddy" \
-  --volicon "$APP_PATH/Contents/Resources/AppIcon.icns" \
   --window-pos 200 120 \
   --window-size 800 400 \
   --icon-size 100 \


### PR DESCRIPTION
Removes the missing AppIcon.icns dependency from the create-dmg script so GitHub Actions can successfully finalize the Ad-Hoc executable packaging phase.