### PR TITLE
[codex] Fix build.sh mlx-swift source path detection

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,7 +30,18 @@ echo "   cmake: $(cmake --version | head -1)"
 echo ""
 echo "=> [3/4] Building Metal kernels (mlx.metallib)..."
 
-MLX_SRC=".build/checkouts/mlx-swift/Source/Cmlx/mlx"
+if [ -d "mlx-swift/Source/Cmlx/mlx" ]; then
+    MLX_SRC="mlx-swift/Source/Cmlx/mlx"
+elif [ -d ".build/checkouts/mlx-swift/Source/Cmlx/mlx" ]; then
+    MLX_SRC=".build/checkouts/mlx-swift/Source/Cmlx/mlx"
+else
+    echo "❌ Could not locate mlx-swift sources."
+    echo "   Expected one of:"
+    echo "   - mlx-swift/Source/Cmlx/mlx"
+    echo "   - .build/checkouts/mlx-swift/Source/Cmlx/mlx"
+    echo "   Make sure submodules are initialized."
+    exit 1
+fi
 METALLIB_BUILD_DIR=".build/metallib_build"
 METALLIB_DEST=".build/arm64-apple-macosx/release"
 


### PR DESCRIPTION
## What changed

This updates `build.sh` to locate `mlx-swift` sources from either of the layouts that can exist in a local checkout:

- `mlx-swift/Source/Cmlx/mlx` (git submodule at repo root)
- `.build/checkouts/mlx-swift/Source/Cmlx/mlx` (SwiftPM checkout layout)

## Why it changed

The current script hardcodes only the SwiftPM checkout path:

- `.build/checkouts/mlx-swift/Source/Cmlx/mlx`

But the documented clone flow in the README uses:

- `git clone --recursive https://github.com/SharpAI/SwiftLM`

In that layout, `mlx-swift` is present as a top-level submodule, so `build.sh` fails before Metal kernel compilation even though the required sources are already available locally.

## Impact

This makes the documented source-build flow more robust and allows `./build.sh` to work in both checkout layouts without any manual path edits.

## Root cause

`build.sh` assumed a single MLX source location that did not match the repo's own submodule layout.

## Validation

- Reproduced the failure locally with the unpatched script.
- Verified the patched script gets past the old failure point and enters CMake/Metal compilation successfully.
- Built the project locally after applying the fix.
