### PR TITLE
fix(build): ensure Homebrew path includes on Apple Silicon for cmake

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eo pipefail
 
+export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+
 echo "=============================================="
 echo "    SwiftLM Build Script                      "
 echo "=============================================="


### PR DESCRIPTION
Fixes #63.

The `build.sh` script natively struggled to resolve `cmake` and `brew` via Homebrew on Apple Silicon Macs when triggered via specific shells because `/opt/homebrew/bin` was not injected into the `$PATH` automatically. This applies a robust fix directly into the shell context.

*(Note: The other root cause of Issue #63 regarding the GLM 5.1 code leakage throwing inconsistent compilation errors has already been resolved natively down the dependency tree by reverting the branch and re-aligning the clean `SwiftLM` submodules in `main`.)*