### PR TITLE
fix(build): safely append Homebrew paths to avoid overriding user toolchains

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 set -eo pipefail
 
-export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+# Safely append Homebrew bins to PATH if they exist, to avoid overriding custom toolchains
+if [[ ":$PATH:" != *":/opt/homebrew/bin:"* ]] && [ -d "/opt/homebrew/bin" ]; then
+    export PATH="$PATH:/opt/homebrew/bin"
+fi
+if [[ ":$PATH:" != *":/usr/local/bin:"* ]] && [ -d "/usr/local/bin" ]; then
+    export PATH="$PATH:/usr/local/bin"
+fi
 
 echo "=============================================="
 echo "    SwiftLM Build Script                      "


### PR DESCRIPTION
Refines the previous `PATH` injection in `build.sh` based on PR review. Instead of globally prepending the Homebrew binary directories, they are now safely appended to the `PATH` only if they exist and are not already present. This ensures that any custom user toolchains (like explicit `cmake` or `swift` paths) take priority while safely falling back to native Homebrew paths on Apple Silicon.