### PR TITLE
fix(dflash): suppress compiler warnings — remove unused var, var→let

### DIFF
--- a/Sources/DFlash/DFlashIntermediateDumper.swift
+++ b/Sources/DFlash/DFlashIntermediateDumper.swift
@@ -42,7 +42,6 @@ public enum DFlashDumper {
         eval(floatArr)
 
         let shape = (0..<floatArr.ndim).map { floatArr.dim($0) }
-        let totalElements = shape.reduce(1, *)
 
         // Build spec-compliant .npy header: shape must be a Python tuple,
         // spaces pad before the final newline byte.

--- a/Sources/DFlash/DFlashRuntime.swift
+++ b/Sources/DFlash/DFlashRuntime.swift
@@ -329,7 +329,7 @@ public enum DFlashRuntime {
 
         let draftBackend = DFlashDraftBackend()
 
-        var targetCache = makeTargetCache(targetModel: targetModel)
+        let targetCache = makeTargetCache(targetModel: targetModel)
 
         let draftCache = draftBackend.makeCache(
             draftModel: draftModel,


### PR DESCRIPTION
Fixes two compiler warnings surfaced in mlx-swift CI ([run log](https://github.com/SharpAI/mlx-swift/actions/runs/24972894001/job/73119164003?pr=10)):

1. **`DFlashIntermediateDumper.swift:45`** — `totalElements` computed but never used. Removed.
2. **`DFlashRuntime.swift:332`** — `var targetCache` never reassigned. Changed to `let`.