### PR TITLE
doc: use xattr to remove quarantine bit to allow running unsigned

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The archive is **self-contained** — `mlx.metallib` is bundled alongside the bi
 
 ```bash
 tar -xzf SwiftLM-<version>-macos-arm64.tar.gz
+xattr -r -d com.apple.quarantine ./SwiftLM ./mlx.metallib
 ./SwiftLM --model mlx-community/Qwen2.5-3B-Instruct-4bit --port 5413
 ```
 


### PR DESCRIPTION
Without this, macOS prompts to delete the file rather than running it.