### PR TITLE
fix: detect MoE across all expert-count config spellings (#112)

### DIFF
--- a/Sources/SwiftLM/ModelProfiler.swift
+++ b/Sources/SwiftLM/ModelProfiler.swift
@@ -175,7 +175,13 @@ enum ModelProfiler {
         let headDim: Int?
         let intermediateSize: Int?
         let vocabSize: Int?
-        let numExperts: Int?
+        // Expert-count spellings differ per architecture family (see `numExperts`):
+        //   num_local_experts  → Mixtral, Phi-MoE
+        //   num_experts        → Qwen3 / Qwen3.5 MoE, Kimi
+        //   n_routed_experts   → DeepSeek V2/V3, GLM4 MoE, MiniMax
+        let numLocalExperts: Int?
+        let numExpertsKey: Int?
+        let nRoutedExperts: Int?
         let numExpertsPerTok: Int?
         let quantizationConfig: QuantConfig?
         let textConfig: TextConfig?
@@ -189,10 +195,23 @@ enum ModelProfiler {
             case headDim = "head_dim"
             case intermediateSize = "intermediate_size"
             case vocabSize = "vocab_size"
-            case numExperts = "num_local_experts"
+            case numLocalExperts = "num_local_experts"
+            case numExpertsKey = "num_experts"
+            case nRoutedExperts = "n_routed_experts"
             case numExpertsPerTok = "num_experts_per_tok"
             case quantizationConfig = "quantization_config"
             case textConfig = "text_config"
+        }
+
+        /// Routed-expert count under whichever key this architecture uses,
+        /// falling back to the nested `text_config` used by multimodal wrappers.
+        var numExperts: Int? {
+            numLocalExperts ?? numExpertsKey ?? nRoutedExperts
+                ?? textConfig?.numLocalExperts ?? textConfig?.numExpertsKey ?? textConfig?.nRoutedExperts
+        }
+
+        var activeExperts: Int? {
+            numExpertsPerTok ?? textConfig?.numExpertsPerTok
         }
     }
 
@@ -204,6 +223,10 @@ enum ModelProfiler {
         let headDim: Int?
         let intermediateSize: Int?
         let vocabSize: Int?
+        let numLocalExperts: Int?
+        let numExpertsKey: Int?
+        let nRoutedExperts: Int?
+        let numExpertsPerTok: Int?
 
         enum CodingKeys: String, CodingKey {
             case numHiddenLayers = "num_hidden_layers"
@@ -213,6 +236,10 @@ enum ModelProfiler {
             case headDim = "head_dim"
             case intermediateSize = "intermediate_size"
             case vocabSize = "vocab_size"
+            case numLocalExperts = "num_local_experts"
+            case numExpertsKey = "num_experts"
+            case nRoutedExperts = "n_routed_experts"
+            case numExpertsPerTok = "num_experts_per_tok"
         }
     }
 
@@ -251,16 +278,24 @@ enum ModelProfiler {
         // Detect quantization
         let quantBits = config.quantizationConfig?.bits ?? detectQuantBits(modelId: modelId)
 
-        // Detect MoE
-        let isMoE = config.numExperts != nil && (config.numExperts ?? 0) > 1
+        // Detect MoE.
+        //
+        // Issue #112: expert counts are spelled differently per architecture family,
+        // so relying on a single key silently misclassified Qwen3.5-MoE / DeepSeek /
+        // GLM MoE models as dense. That disabled --stream-experts and made the server
+        // materialise the full model, which the OS then OOM-killed. `config.numExperts`
+        // now consults every known spelling; the model_type check is a last-resort
+        // fallback for families that name the key something we have not seen yet.
         let numExperts = config.numExperts
-        let numActiveExperts = config.numExpertsPerTok
+        let numActiveExperts = config.activeExperts
+        let modelType = config.modelType ?? "unknown"
+        let isMoE = (numExperts ?? 0) > 1 || modelTypeImpliesMoE(modelType)
 
         // Measure weight file sizes on disk (only for MoE to avoid slow walks on dense models)
         let weightSize = isMoE ? measureWeightFiles(directory: modelDirectory) : 0
 
         return ModelProfile(
-            modelType: config.modelType ?? "unknown",
+            modelType: modelType,
             numLayers: numLayers,
             hiddenSize: hiddenSize,
             numAttentionHeads: numHeads,
@@ -275,6 +310,15 @@ enum ModelProfiler {
             weightFileSizeBytes: weightSize,
             modelId: modelId
         )
+    }
+
+    /// Last-resort MoE detection for configs whose expert-count key we do not know.
+    /// Only used when no expert count was found, so a false positive here costs a
+    /// weight-file walk, while a false negative costs an OOM kill (issue #112).
+    static func modelTypeImpliesMoE(_ modelType: String) -> Bool {
+        let normalized = modelType.lowercased().replacingOccurrences(of: "-", with: "_")
+        if normalized.contains("moe") { return true }
+        return ["mixtral", "dbrx", "grok"].contains { normalized.contains($0) }
     }
 
     /// Detect quantization bits from model ID string patterns.

--- a/Sources/SwiftLM/ModelProfiler.swift
+++ b/Sources/SwiftLM/ModelProfiler.swift
@@ -203,11 +203,21 @@ enum ModelProfiler {
             case textConfig = "text_config"
         }
 
-        /// Routed-expert count under whichever key this architecture uses,
-        /// falling back to the nested `text_config` used by multimodal wrappers.
+        /// Every routed-expert count present, in precedence order: this architecture's
+        /// own spelling first, then the nested `text_config` used by multimodal wrappers.
+        var expertCountCandidates: [Int] {
+            [
+                numLocalExperts, numExpertsKey, nRoutedExperts,
+                textConfig?.numLocalExperts, textConfig?.numExpertsKey, textConfig?.nRoutedExperts,
+            ].compactMap { $0 }
+        }
+
+        /// Routed-expert count. Prefers a plausible count over a degenerate one, so a
+        /// top-level `"num_experts": 0` placeholder in a multimodal wrapper cannot mask a
+        /// real count nested under `text_config`.
         var numExperts: Int? {
-            numLocalExperts ?? numExpertsKey ?? nRoutedExperts
-                ?? textConfig?.numLocalExperts ?? textConfig?.numExpertsKey ?? textConfig?.nRoutedExperts
+            let candidates = expertCountCandidates
+            return candidates.first { $0 > 1 } ?? candidates.first
         }
 
         var activeExperts: Int? {
@@ -284,12 +294,15 @@ enum ModelProfiler {
         // so relying on a single key silently misclassified Qwen3.5-MoE / DeepSeek /
         // GLM MoE models as dense. That disabled --stream-experts and made the server
         // materialise the full model, which the OS then OOM-killed. `config.numExperts`
-        // now consults every known spelling; the model_type check is a last-resort
-        // fallback for families that name the key something we have not seen yet.
+        // now consults every known spelling.
+        //
+        // An explicit count is authoritative in both directions: a config that says it
+        // has one expert is dense, whatever its model_type is called. The model_type
+        // heuristic applies only when no known key was present at all.
         let numExperts = config.numExperts
         let numActiveExperts = config.activeExperts
         let modelType = config.modelType ?? "unknown"
-        let isMoE = (numExperts ?? 0) > 1 || modelTypeImpliesMoE(modelType)
+        let isMoE = numExperts.map { $0 > 1 } ?? modelTypeImpliesMoE(modelType)
 
         // Measure weight file sizes on disk (only for MoE to avoid slow walks on dense models)
         let weightSize = isMoE ? measureWeightFiles(directory: modelDirectory) : 0
@@ -313,10 +326,15 @@ enum ModelProfiler {
     }
 
     /// Last-resort MoE detection for configs whose expert-count key we do not know.
-    /// Only used when no expert count was found, so a false positive here costs a
-    /// weight-file walk, while a false negative costs an OOM kill (issue #112).
+    /// Reached only when no known expert key was present at all.
+    ///
+    /// A false positive is not free: it clears the guard in Server.swift, which then
+    /// enables lazy loading, activates SSD expert streaming and overrides the MLX
+    /// memory and cache limits. It is still the safer direction — that path only runs
+    /// when the user explicitly passed --stream-experts, whereas a false negative
+    /// materialises the whole model and gets the process OOM-killed (issue #112).
     static func modelTypeImpliesMoE(_ modelType: String) -> Bool {
-        let normalized = modelType.lowercased().replacingOccurrences(of: "-", with: "_")
+        let normalized = modelType.lowercased()
         if normalized.contains("moe") { return true }
         return ["mixtral", "dbrx", "grok"].contains { normalized.contains($0) }
     }

--- a/Sources/SwiftLM/ModelProfiler.swift
+++ b/Sources/SwiftLM/ModelProfiler.swift
@@ -203,25 +203,31 @@ enum ModelProfiler {
             case textConfig = "text_config"
         }
 
-        /// Every routed-expert count present, in precedence order: this architecture's
-        /// own spelling first, then the nested `text_config` used by multimodal wrappers.
+        /// Every positive routed-expert count present, in precedence order: this
+        /// architecture's own spelling first, then the nested `text_config` used by
+        /// multimodal wrappers. Non-positive values are placeholders (a vision wrapper's
+        /// `"num_experts": 0`), not declarations, so they are dropped here — which also
+        /// means a lone `0` leaves the count absent and the model_type heuristic still
+        /// applies, rather than silently re-opening the #112 OOM path.
         var expertCountCandidates: [Int] {
             [
                 numLocalExperts, numExpertsKey, nRoutedExperts,
                 textConfig?.numLocalExperts, textConfig?.numExpertsKey, textConfig?.nRoutedExperts,
-            ].compactMap { $0 }
+            ].compactMap { $0 }.filter { $0 > 0 }
         }
 
-        /// Routed-expert count. Prefers a plausible count over a degenerate one, so a
-        /// top-level `"num_experts": 0` placeholder in a multimodal wrapper cannot mask a
-        /// real count nested under `text_config`.
+        /// Routed-expert count: the first positive value in precedence order. Taking the
+        /// first — rather than preferring any value > 1 — keeps an explicit outer count
+        /// of 1 authoritative over a stale nested count left behind by a dense
+        /// conversion, while the positivity filter above stops a `0` placeholder from
+        /// masking the real nested value.
         var numExperts: Int? {
-            let candidates = expertCountCandidates
-            return candidates.first { $0 > 1 } ?? candidates.first
+            expertCountCandidates.first
         }
 
         var activeExperts: Int? {
-            numExpertsPerTok ?? textConfig?.numExpertsPerTok
+            [numExpertsPerTok, textConfig?.numExpertsPerTok]
+                .compactMap { $0 }.first { $0 > 0 }
         }
     }
 

--- a/Sources/SwiftLM/Server.swift
+++ b/Sources/SwiftLM/Server.swift
@@ -346,7 +346,9 @@ struct MLXServer: AsyncParsableCommand {
             // and erroneous auto-capping of draft tokens.
             if let profile = mainModelProfile, !profile.isMoE {
                 print("[SwiftLM] ⚠️  Model does not support SSD expert streaming (\(profile.modelType) is not MoE). Ignoring --stream-experts flag.")
-                print("[SwiftLM]    No routed-expert count found in config.json (num_local_experts / num_experts / n_routed_experts).")
+                let countDescription = profile.numExperts.map { "routed-expert count is \($0)" }
+                    ?? "no routed-expert count found in config.json (num_local_experts / num_experts / n_routed_experts)"
+                print("[SwiftLM]    \(countDescription).")
                 print("[SwiftLM]    If this model *is* MoE, please report it — see issue #112.")
                 self.streamExperts = false
             }

--- a/Sources/SwiftLM/Server.swift
+++ b/Sources/SwiftLM/Server.swift
@@ -346,6 +346,8 @@ struct MLXServer: AsyncParsableCommand {
             // and erroneous auto-capping of draft tokens.
             if let profile = mainModelProfile, !profile.isMoE {
                 print("[SwiftLM] ⚠️  Model does not support SSD expert streaming (\(profile.modelType) is not MoE). Ignoring --stream-experts flag.")
+                print("[SwiftLM]    No routed-expert count found in config.json (num_local_experts / num_experts / n_routed_experts).")
+                print("[SwiftLM]    If this model *is* MoE, please report it — see issue #112.")
                 self.streamExperts = false
             }
         }

--- a/tests/SwiftLMTests/ModelProfilerMoEDetectionTests.swift
+++ b/tests/SwiftLMTests/ModelProfilerMoEDetectionTests.swift
@@ -118,6 +118,44 @@ final class ModelProfilerMoEDetectionTests: XCTestCase {
         XCTAssertEqual(p.numLayers, 48, "layer count must still come from text_config")
     }
 
+    /// The exact config shape from the runtime validation on #114:
+    /// `lmstudio-community/Qwen3.6-35B-A3B-MLX-8bit` — a multimodal MoE whose
+    /// top level carries no expert keys at all, only `vision_config` and a
+    /// `text_config` holding `num_experts`. Reported as `qwen3_5_moe is not MoE`
+    /// before the fix, with the model profiled at a few GB instead of 37.7 GB.
+    func testQwen36VisionMoENestedConfig() throws {
+        let p = try profile(config: """
+        {
+          "model_type": "qwen3_5_moe",
+          "architectures": ["Qwen3_5_MoeForConditionalGeneration"],
+          "image_token_id": 151655,
+          "vision_config": { "depth": 27, "hidden_size": 1152 },
+          "text_config": {
+            "model_type": "qwen3_5_moe_text",
+            "num_hidden_layers": 40,
+            "hidden_size": 2048,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 2,
+            "head_dim": 256,
+            "vocab_size": 248320,
+            "num_experts": 256,
+            "num_experts_per_tok": 8,
+            "moe_intermediate_size": 512
+          }
+        }
+        """, modelId: "lmstudio-community/Qwen3.6-35B-A3B-MLX-8bit")
+
+        XCTAssertTrue(p.isMoE)
+        // The counts must come from text_config. Without the nested lookup these are
+        // nil even though the model_type heuristic would still flag the model as MoE,
+        // so this is what distinguishes a real fix from an accidental pass.
+        XCTAssertEqual(p.numExperts, 256)
+        XCTAssertEqual(p.numActiveExperts, 8)
+        XCTAssertEqual(p.numLayers, 40, "layer count must come from text_config")
+        XCTAssertEqual(p.numKVHeads, 2)
+        XCTAssertEqual(p.headDim, 256)
+    }
+
     // MARK: Fallback + negative cases
 
     /// A config using an expert-count key we have not seen still profiles as MoE

--- a/tests/SwiftLMTests/ModelProfilerMoEDetectionTests.swift
+++ b/tests/SwiftLMTests/ModelProfilerMoEDetectionTests.swift
@@ -172,6 +172,43 @@ final class ModelProfilerMoEDetectionTests: XCTestCase {
         XCTAssertNil(p.numExperts, "no known expert key present, so the count stays unknown")
     }
 
+    /// An explicit expert count wins over the model_type heuristic. A config that says
+    /// it has one expert is dense even when its name contains "moe" — otherwise a
+    /// dense-converted or ablation checkpoint would enable SSD streaming with no experts
+    /// to stream (review finding on #114).
+    func testExplicitSingleExpertBeatsModelTypeHeuristic() throws {
+        let p = try profile(config: """
+        {
+          \(baseKeys(modelType: "qwen3_5_moe")),
+          "num_experts": 1
+        }
+        """)
+
+        XCTAssertFalse(p.isMoE, "an explicit count of 1 is authoritative over the name heuristic")
+        XCTAssertEqual(p.numExperts, 1)
+    }
+
+    /// A degenerate top-level value must not mask a real count nested under text_config.
+    /// Multimodal wrappers can carry a placeholder at the top level (review finding on #114).
+    func testDegenerateTopLevelDoesNotShadowNestedCount() throws {
+        let p = try profile(config: """
+        {
+          "model_type": "some_wrapper",
+          "num_experts": 0,
+          "text_config": {
+            "num_hidden_layers": 40,
+            "hidden_size": 2048,
+            "num_experts": 128,
+            "num_experts_per_tok": 8
+          }
+        }
+        """)
+
+        XCTAssertTrue(p.isMoE, "the nested count is the real one")
+        XCTAssertEqual(p.numExperts, 128, "a top-level 0 must not shadow text_config")
+        XCTAssertEqual(p.numActiveExperts, 8)
+    }
+
     func testModelTypeHeuristic() {
         for type in ["qwen3_5_moe", "glm4_moe", "GLM-MoE", "mixtral", "dbrx", "grok_1"] {
             XCTAssertTrue(ModelProfiler.modelTypeImpliesMoE(type), "\(type) should imply MoE")

--- a/tests/SwiftLMTests/ModelProfilerMoEDetectionTests.swift
+++ b/tests/SwiftLMTests/ModelProfilerMoEDetectionTests.swift
@@ -1,0 +1,175 @@
+import XCTest
+import Foundation
+@testable import SwiftLM
+
+// MARK: - Regression tests for Issue #112 — MoE detection across architecture families
+//
+// Root cause: ModelProfiler decoded the routed-expert count from `num_local_experts`
+// only — the Mixtral spelling. Qwen3/Qwen3.5 MoE use `num_experts`, DeepSeek V2/V3 and
+// GLM MoE use `n_routed_experts`. Those models profiled as dense, so Server.swift
+// disabled --stream-experts ("qwen3_5_moe is not MoE"), never set lazyLoad, and the
+// full model was materialised into RAM — the OS then OOM-killed the process.
+//
+// These tests lock in that every known expert-count spelling is recognised, that the
+// nested text_config form works, and that dense models stay dense.
+final class ModelProfilerMoEDetectionTests: XCTestCase {
+
+    private var tempRoot: URL!
+
+    override func setUpWithError() throws {
+        tempRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("swiftlm-moe-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempRoot)
+    }
+
+    /// Writes a config.json into a fresh directory and profiles it.
+    private func profile(config: String, modelId: String = "test/model") throws -> ModelProfile {
+        let dir = tempRoot.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try config.write(to: dir.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+        let profile = ModelProfiler.profile(modelDirectory: dir, modelId: modelId)
+        return try XCTUnwrap(profile, "profile() returned nil for config: \(config)")
+    }
+
+    private func baseKeys(modelType: String) -> String {
+        """
+        "model_type": "\(modelType)",
+        "num_hidden_layers": 48,
+        "hidden_size": 4096,
+        "num_attention_heads": 32,
+        "num_key_value_heads": 4,
+        "intermediate_size": 12288,
+        "vocab_size": 151936
+        """
+    }
+
+    // MARK: Expert-count spellings
+
+    /// Qwen3.5-MoE — the model from the issue report. Uses `num_experts`.
+    func testQwen35MoEDetectedViaNumExperts() throws {
+        let p = try profile(config: """
+        {
+          \(baseKeys(modelType: "qwen3_5_moe")),
+          "num_experts": 128,
+          "num_experts_per_tok": 8
+        }
+        """, modelId: "/Users/user/models/Qwen3.5-397B-A17B-mxfp8-grp32")
+
+        XCTAssertTrue(p.isMoE, "qwen3_5_moe with num_experts=128 must profile as MoE (issue #112)")
+        XCTAssertEqual(p.numExperts, 128)
+        XCTAssertEqual(p.numActiveExperts, 8)
+    }
+
+    /// Mixtral / Phi-MoE — `num_local_experts`. The only spelling that worked before.
+    func testMixtralDetectedViaNumLocalExperts() throws {
+        let p = try profile(config: """
+        {
+          \(baseKeys(modelType: "mixtral")),
+          "num_local_experts": 8,
+          "num_experts_per_tok": 2
+        }
+        """)
+
+        XCTAssertTrue(p.isMoE)
+        XCTAssertEqual(p.numExperts, 8)
+        XCTAssertEqual(p.numActiveExperts, 2)
+    }
+
+    /// DeepSeek V3 / GLM4 MoE / MiniMax — `n_routed_experts`.
+    func testDeepSeekDetectedViaNRoutedExperts() throws {
+        let p = try profile(config: """
+        {
+          \(baseKeys(modelType: "deepseek_v3")),
+          "n_routed_experts": 256,
+          "num_experts_per_tok": 8
+        }
+        """)
+
+        XCTAssertTrue(p.isMoE)
+        XCTAssertEqual(p.numExperts, 256)
+        XCTAssertEqual(p.numActiveExperts, 8)
+    }
+
+    /// Multimodal wrappers nest the language-model config under `text_config`.
+    func testNestedTextConfigExpertCount() throws {
+        let p = try profile(config: """
+        {
+          "model_type": "qwen3_vl_moe",
+          "text_config": {
+            "num_hidden_layers": 48,
+            "hidden_size": 4096,
+            "num_attention_heads": 32,
+            "num_key_value_heads": 4,
+            "intermediate_size": 12288,
+            "vocab_size": 151936,
+            "num_experts": 128,
+            "num_experts_per_tok": 8
+          }
+        }
+        """)
+
+        XCTAssertTrue(p.isMoE)
+        XCTAssertEqual(p.numExperts, 128)
+        XCTAssertEqual(p.numActiveExperts, 8)
+        XCTAssertEqual(p.numLayers, 48, "layer count must still come from text_config")
+    }
+
+    // MARK: Fallback + negative cases
+
+    /// A config using an expert-count key we have not seen still profiles as MoE
+    /// when model_type says so — the OOM-safe direction.
+    func testUnknownExpertKeyFallsBackToModelType() throws {
+        let p = try profile(config: """
+        {
+          \(baseKeys(modelType: "some_new_moe")),
+          "n_future_experts": 64
+        }
+        """)
+
+        XCTAssertTrue(p.isMoE, "model_type containing 'moe' must be treated as MoE")
+        XCTAssertNil(p.numExperts, "no known expert key present, so the count stays unknown")
+    }
+
+    func testModelTypeHeuristic() {
+        for type in ["qwen3_5_moe", "glm4_moe", "GLM-MoE", "mixtral", "dbrx", "grok_1"] {
+            XCTAssertTrue(ModelProfiler.modelTypeImpliesMoE(type), "\(type) should imply MoE")
+        }
+        for type in ["qwen3_5", "llama", "gemma3", "phi3", "mistral", "unknown"] {
+            XCTAssertFalse(ModelProfiler.modelTypeImpliesMoE(type), "\(type) must not imply MoE")
+        }
+    }
+
+    /// Dense models must stay dense — otherwise --stream-experts would be honoured
+    /// on a model with no experts to stream.
+    func testDenseModelIsNotMoE() throws {
+        let p = try profile(config: """
+        { \(baseKeys(modelType: "qwen3_5")) }
+        """)
+
+        XCTAssertFalse(p.isMoE)
+        XCTAssertNil(p.numExperts)
+    }
+
+    /// A single "expert" is a dense FFN in disguise; the pre-fix guard required > 1
+    /// and that threshold must survive.
+    func testSingleExpertIsNotMoE() throws {
+        let p = try profile(config: """
+        {
+          \(baseKeys(modelType: "custom_arch")),
+          "num_experts": 1
+        }
+        """)
+
+        XCTAssertFalse(p.isMoE, "num_experts=1 is a dense FFN, not a MoE")
+    }
+
+    func testMissingConfigReturnsNil() {
+        let dir = tempRoot.appendingPathComponent("empty")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        XCTAssertNil(ModelProfiler.profile(modelDirectory: dir, modelId: "test/model"))
+    }
+}

--- a/tests/SwiftLMTests/ModelProfilerMoEDetectionTests.swift
+++ b/tests/SwiftLMTests/ModelProfilerMoEDetectionTests.swift
@@ -209,6 +209,36 @@ final class ModelProfilerMoEDetectionTests: XCTestCase {
         XCTAssertEqual(p.numActiveExperts, 8)
     }
 
+    /// A lone explicit 0 is a placeholder, not a declaration: the heuristic must still
+    /// apply, or a wrapper whose real count uses an unknown spelling would profile as
+    /// dense and re-open the #112 OOM path (review finding on #114).
+    func testLoneZeroDoesNotSuppressHeuristic() throws {
+        let p = try profile(config: """
+        {
+          \(baseKeys(modelType: "some_new_moe")),
+          "num_experts": 0
+        }
+        """)
+
+        XCTAssertTrue(p.isMoE, "a 0 placeholder must not veto the model_type heuristic")
+        XCTAssertNil(p.numExperts)
+    }
+
+    /// An explicit outer count of 1 stays authoritative even when a stale nested count
+    /// survives from the base model of a dense conversion (review finding on #114).
+    func testExplicitOneBeatsStaleNestedCount() throws {
+        let p = try profile(config: """
+        {
+          \(baseKeys(modelType: "custom_arch")),
+          "num_local_experts": 1,
+          "text_config": { "num_experts": 128 }
+        }
+        """)
+
+        XCTAssertFalse(p.isMoE, "outer explicit 1 wins over a stale nested 128")
+        XCTAssertEqual(p.numExperts, 1)
+    }
+
     func testModelTypeHeuristic() {
         for type in ["qwen3_5_moe", "glm4_moe", "GLM-MoE", "mixtral", "dbrx", "grok_1"] {
             XCTAssertTrue(ModelProfiler.modelTypeImpliesMoE(type), "\(type) should imply MoE")


### PR DESCRIPTION
Fixes #112.

## Root cause

`ModelProfiler` decoded the routed-expert count from a single key:

```swift
case numExperts = "num_local_experts"   // ModelProfiler.swift:192
let isMoE = config.numExperts != nil && (config.numExperts ?? 0) > 1
```

`num_local_experts` is the **Mixtral** spelling. Qwen3/Qwen3.5 MoE use `num_experts`; DeepSeek V2/V3, GLM MoE and MiniMax use `n_routed_experts` — both already known elsewhere in this repo (`DeepseekV3DFlash.swift:59`, `KimiLinearDFlash.swift:83`).

So `profile.isMoE` was false for Qwen3.5-397B-A17B and `Server.swift:347` silently dropped `--stream-experts`. The reporter's own log confirms it: `qwen3_5_moe is not MoE`.

The `zsh: killed` follows directly — with streaming off, `modelConfig.lazyLoad` is never set (`Server.swift:355`), so the full 397B model is materialised and the OS OOM-kills the process. That also explains why b648 (before the guard landed) worked.

## Changes

- **`ModelProfiler.swift`** — decode all three spellings, plus the same keys nested under `text_config` for multimodal wrappers, resolved in `ModelConfig.numExperts`.
- **`modelTypeImpliesMoE()`** — last-resort fallback for families whose expert key we haven't seen (any `model_type` containing `moe`, plus `mixtral`/`dbrx`/`grok`). The asymmetry is deliberate: a false positive costs a weight-file walk, a false negative costs an OOM kill.
- The `> 1` threshold is preserved, so a single-expert (dense FFN) config stays dense.
- **`Server.swift:347`** — the rejection message now names the keys it looked for, so the next misdetection is diagnosable from the log alone.

## Tests

New `tests/SwiftLMTests/ModelProfilerMoEDetectionTests.swift` — 9 tests writing real `config.json` fixtures through `ModelProfiler.profile()`: one per spelling (the Qwen3.5 case reproduces the issue's exact model), nested `text_config`, the unknown-key fallback, and negatives for dense / single-expert / missing config.

Verified red against the pre-fix logic — 7 of the 9 fail, including `testQwen35MoEDetectedViaNumExperts`. Green after: 9/9.

Full `SwiftLMTests` run: 86 tests across 8 suites, 0 failures. `PromptCacheTests` aborts under `swift test` with `Failed to load the default metallib` — reproduced at HEAD without these changes, so it is pre-existing and environmental.

Not covered here: the reporter should confirm the actual `--stream-experts` run on their 397B model, since the OOM path itself is hardware-dependent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)