### PR TITLE
fix: parse reasoning when the chat template pre-opens <think> (#108)

### DIFF
--- a/Sources/SwiftLM/Server.swift
+++ b/Sources/SwiftLM/Server.swift
@@ -1491,6 +1491,22 @@ func handleChatCompletion(
     let promptTokenCount = lmInput.text.tokens.size
     let promptTokens = lmInput.text.tokens.asArray(Int.self)
 
+    // ── Issue #108: does the template leave the thinking block open? ──
+    // Qwen3/3.5/3.6 templates append `<think>\n` to the generation prompt when
+    // enable_thinking is true, so the model emits reasoning with no opening tag of
+    // its own and the parser would misfile all of it as response content. Decoding
+    // the prompt tail detects this without hard-coding any particular template:
+    // 32 tokens comfortably covers the trailing `<|im_start|>assistant\n<think>\n`
+    // while keeping the decode negligible.
+    var thinkingPreOpened = false
+    if enableThinking {
+        let tail = await container.tokenizer.decode(tokenIds: Array(promptTokens.suffix(32)), skipSpecialTokens: false)
+        thinkingPreOpened = ThinkingStateTracker.opensUnclosedThinkingBlock(tail)
+        if thinkingPreOpened {
+            print("[SwiftLM] Chat template pre-opened the thinking block — parsing output as reasoning until the closing tag.")
+        }
+    }
+
     // llama-server style: announce prefill start
     print("srv  slot_launch: id 0 | prompt=\(promptTokenCount)t | thinking=\(enableThinking) | prefilling...")
     fflush(stdout)
@@ -1544,7 +1560,8 @@ func handleChatCompletion(
             return handleChatStreaming(
                 stream: genStream, modelId: modelId, stopSequences: stopSequences,
                 includeUsage: includeUsage, promptTokenCount: promptTokenCount,
-                enableThinking: enableThinking, jsonMode: jsonMode, semaphore: semaphore,
+                enableThinking: enableThinking, thinkingPreOpened: thinkingPreOpened,
+                jsonMode: jsonMode, semaphore: semaphore,
                 stats: stats, genStart: genStart, prefillStart: prefillStart,
                 emitPrefillProgress: false, onPrefillDone: nil
             )
@@ -1552,7 +1569,7 @@ func handleChatCompletion(
             return try await handleChatNonStreaming(
                 stream: genStream, modelId: modelId, stopSequences: stopSequences,
                 promptTokenCount: promptTokenCount, enableThinking: enableThinking,
-                jsonMode: jsonMode, semaphore: semaphore,
+                thinkingPreOpened: thinkingPreOpened, jsonMode: jsonMode, semaphore: semaphore,
                 stats: stats, genStart: genStart, prefillStart: prefillStart, onPrefillDone: nil
             )
         }
@@ -1670,7 +1687,8 @@ func handleChatCompletion(
         return handleChatStreaming(
             stream: stream, modelId: modelId, stopSequences: stopSequences,
             includeUsage: includeUsage, promptTokenCount: promptTokenCount,
-            enableThinking: enableThinking, jsonMode: jsonMode, semaphore: semaphore,
+            enableThinking: enableThinking, thinkingPreOpened: thinkingPreOpened,
+            jsonMode: jsonMode, semaphore: semaphore,
             stats: stats, genStart: genStart, prefillStart: prefillStart,
             emitPrefillProgress: emitPrefillProgress, onPrefillDone: onPrefillDone
         )
@@ -1678,7 +1696,7 @@ func handleChatCompletion(
         return try await handleChatNonStreaming(
             stream: stream, modelId: modelId, stopSequences: stopSequences,
             promptTokenCount: promptTokenCount, enableThinking: enableThinking,
-            jsonMode: jsonMode, semaphore: semaphore,
+            thinkingPreOpened: thinkingPreOpened, jsonMode: jsonMode, semaphore: semaphore,
             stats: stats, genStart: genStart, prefillStart: prefillStart, onPrefillDone: onPrefillDone
         )
     }
@@ -1695,6 +1713,33 @@ struct ThinkingStateTracker {
     private(set) var phase: Phase = .responding
     private var buffer = ""  // accumulates chars looking for tag boundaries
 
+    /// Opening/closing tag spellings, longest-first so `<thinking>` is preferred
+    /// over the `<think>` prefix when both could match.
+    static let openTags = ["<thinking>", "<think>", "<|channel>thought\n", "<|channel>thought"]
+    static let closeTags = ["</thinking>", "</think>", "<channel|>"]
+
+    /// - Parameter startInThinking: true when the chat template already emitted an
+    ///   unclosed opening tag at the end of the prompt, so the model's first token
+    ///   is reasoning rather than response text (issue #108).
+    init(startInThinking: Bool = false) {
+        self.phase = startInThinking ? .thinking : .responding
+    }
+
+    /// Whether a rendered prompt ends inside an unclosed thinking block.
+    ///
+    /// Qwen3/3.5/3.6 templates append `<think>\n` to the generation prompt when
+    /// enable_thinking is true (and `<think>\n\n</think>\n\n` when it is false), so
+    /// the opening tag never appears in the model's own output. Comparing the last
+    /// opening tag against the last closing tag distinguishes the two cases.
+    static func opensUnclosedThinkingBlock(_ prompt: String) -> Bool {
+        func lastIndex(of tags: [String]) -> String.Index? {
+            tags.compactMap { prompt.range(of: $0, options: .backwards)?.lowerBound }.max()
+        }
+        guard let lastOpen = lastIndex(of: openTags) else { return false }
+        guard let lastClose = lastIndex(of: closeTags) else { return true }
+        return lastOpen > lastClose
+    }
+
     /// Feed the next text fragment. Returns (reasoningContent, responseContent)
     /// where either value may be empty but never both non-empty simultaneously.
     mutating func process(_ text: String) -> (reasoning: String, content: String) {
@@ -1705,13 +1750,13 @@ struct ThinkingStateTracker {
         while !buffer.isEmpty {
             switch phase {
             case .responding:
-                let startRange = buffer.range(of: "<thinking>") ?? buffer.range(of: "<think>") ?? buffer.range(of: "<|channel>thought\n") ?? buffer.range(of: "<|channel>thought")
+                let startRange = Self.firstRange(in: buffer, of: Self.openTags)
                 if let range = startRange {
                     // Flush text before the tag as response content
                     content += String(buffer[buffer.startIndex..<range.lowerBound])
                     buffer.removeSubrange(buffer.startIndex..<range.upperBound)
                     phase = .thinking
-                } else if isSuffixOfTag(buffer, tags: ["<think>", "<thinking>", "<|channel>thought\n", "<|channel>thought"]) {
+                } else if isSuffixOfTag(buffer, tags: Self.openTags) {
                     // Partial tag — hold in buffer until we know more
                     return (reasoning, content)
                 } else {
@@ -1719,13 +1764,13 @@ struct ThinkingStateTracker {
                     buffer = ""
                 }
             case .thinking:
-                let endRange = buffer.range(of: "</thinking>") ?? buffer.range(of: "</think>") ?? buffer.range(of: "<channel|>")
+                let endRange = Self.firstRange(in: buffer, of: Self.closeTags)
                 if let range = endRange {
                     // Flush reasoning before the closing tag
                     reasoning += String(buffer[buffer.startIndex..<range.lowerBound])
                     buffer.removeSubrange(buffer.startIndex..<range.upperBound)
                     phase = .responding
-                } else if isSuffixOfTag(buffer, tags: ["</think>", "</thinking>", "<channel|>"]) {
+                } else if isSuffixOfTag(buffer, tags: Self.closeTags) {
                     // Partial closing tag — hold in buffer
                     return (reasoning, content)
                 } else {
@@ -1735,6 +1780,24 @@ struct ThinkingStateTracker {
             }
         }
         return (reasoning, content)
+    }
+
+    /// Drains any text still held in the buffer waiting on a partial tag that never
+    /// completed. Call once when generation ends, otherwise a response whose final
+    /// characters look like the start of a tag (e.g. a trailing "<") is silently
+    /// truncated (issue #108).
+    mutating func flush() -> (reasoning: String, content: String) {
+        defer { buffer = "" }
+        guard !buffer.isEmpty else { return ("", "") }
+        return phase == .thinking ? (buffer, "") : ("", buffer)
+    }
+
+    /// Earliest match of any tag, preferring the longest tag when several start at
+    /// the same offset (so `<thinking>` is not consumed as `<think>` + "ing>").
+    private static func firstRange(in s: String, of tags: [String]) -> Range<String.Index>? {
+        tags.compactMap { s.range(of: $0) }.min { a, b in
+            a.lowerBound == b.lowerBound ? a.upperBound > b.upperBound : a.lowerBound < b.lowerBound
+        }
     }
 
     private func isSuffixOfTag(_ s: String, tags: [String]) -> Bool {
@@ -1767,6 +1830,7 @@ func handleChatStreaming(
     includeUsage: Bool,
     promptTokenCount: Int,
     enableThinking: Bool = false,
+    thinkingPreOpened: Bool = false,
     jsonMode: Bool = false,
     semaphore: AsyncSemaphore,
     stats: ServerStats,
@@ -1816,7 +1880,7 @@ func handleChatStreaming(
         var fullText = ""
         var stopped = false
         var firstToken = true
-        var tracker = ThinkingStateTracker()
+        var tracker = ThinkingStateTracker(startInThinking: enableThinking && thinkingPreOpened)
         // Unconditional cleanup: guarantees heartbeat is cancelled on ALL exit paths
         // (normal completion, client disconnect, or task cancellation during prefill).
         defer {
@@ -1947,6 +2011,17 @@ func handleChatStreaming(
                     case .cancelled, .stop:
                         reason = hasToolCalls ? "tool_calls" : "stop"
                     }
+                    // Drain text the tracker was holding on a partial tag that never
+                    // completed, otherwise the tail of the response is dropped (#108).
+                    if enableThinking {
+                        let (r, c) = tracker.flush()
+                        if !r.isEmpty || !c.isEmpty {
+                            cont.yield(sseChunk(modelId: modelId,
+                                                reasoningContent: r.isEmpty ? nil : r,
+                                                content: c.isEmpty ? nil : c,
+                                                finishReason: nil))
+                        }
+                    }
                     cont.yield(sseChunk(modelId: modelId, reasoningContent: nil, content: nil, finishReason: reason))
                     let genDur = Date().timeIntervalSince(genStart)
                     let genTokPerSec = genDur > 0 ? Double(completionTokenCount) / genDur : 0
@@ -2003,6 +2078,7 @@ func handleChatNonStreaming(
     stopSequences: [String],
     promptTokenCount: Int,
     enableThinking: Bool = false,
+    thinkingPreOpened: Bool = false,
     jsonMode: Bool = false,
     semaphore: AsyncSemaphore,
     stats: ServerStats,
@@ -2074,7 +2150,7 @@ func handleChatNonStreaming(
     var responseContent = fullText
     if enableThinking {
         print("srv debug: pre-extract fullText=\(fullText.prefix(40).debugDescription)")
-        let (extracted, remaining) = extractThinkingBlock(from: fullText)
+        let (extracted, remaining) = extractThinkingBlock(from: fullText, alreadyOpen: thinkingPreOpened)
         print("srv debug: extracted=\(extracted != nil ? "true" : "false"), remaining_len=\(remaining.count)")
         if let extracted {
             reasoningContent = extracted
@@ -2133,10 +2209,26 @@ func handleChatNonStreaming(
 }
 
 /// Returns (thinkingContent, remainingContent) or (nil, original) if no block found.
-func extractThinkingBlock(from text: String) -> (String?, String) {
+///
+/// - Parameter alreadyOpen: true when the chat template pre-opened the thinking block
+///   at the end of the prompt, so `text` starts *inside* the block with no opening tag
+///   of its own (issue #108). Everything up to the first closing tag is reasoning.
+func extractThinkingBlock(from text: String, alreadyOpen: Bool = false) -> (String?, String) {
     let startTag = text.range(of: "<thinking>") ?? text.range(of: "<think>") ?? text.range(of: "<|channel>thought\n") ?? text.range(of: "<|channel>thought") ?? (text.hasPrefix("thought\n") ? text.range(of: "thought\n") : nil)
     let endTag = text.range(of: "</thinking>") ?? text.range(of: "</think>") ?? text.range(of: "<channel|>")
-    
+
+    // Template pre-opened the block and the model did not re-emit an opening tag:
+    // treat the start of the text as the start of the reasoning.
+    if alreadyOpen, startTag == nil {
+        guard let endRange = endTag else {
+            // Still thinking when generation stopped — no response content yet.
+            return (text.isEmpty ? nil : text, "")
+        }
+        let thinking = String(text[text.startIndex..<endRange.lowerBound])
+        let remaining = String(text[endRange.upperBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
+        return (thinking.isEmpty ? nil : thinking, remaining)
+    }
+
     guard let startRange = startTag, let endRange = endTag else {
         // If there's an unclosed thinking block (still thinking when stopped)
         if let startRange = startTag {

--- a/Sources/SwiftLM/Server.swift
+++ b/Sources/SwiftLM/Server.swift
@@ -1733,8 +1733,14 @@ struct ThinkingStateTracker {
     /// opening tag against the last closing tag distinguishes the two cases.
     static func opensUnclosedThinkingBlock(_ prompt: String) -> Bool {
         func lastRange(of tags: [String]) -> Range<String.Index>? {
+            // Latest start wins; on a tie the longest tag wins, so `<thinking>` is
+            // never resolved as `<think>` + "ing>" regardless of openTags order.
             tags.compactMap { prompt.range(of: $0, options: .backwards) }
-                .max { $0.lowerBound < $1.lowerBound }
+                .max { a, b in
+                    a.lowerBound == b.lowerBound
+                        ? a.upperBound < b.upperBound
+                        : a.lowerBound < b.lowerBound
+                }
         }
         guard let lastOpen = lastRange(of: openTags) else { return false }
         if let lastClose = lastRange(of: closeTags), lastClose.lowerBound > lastOpen.lowerBound {
@@ -1961,18 +1967,29 @@ func handleChatStreaming(
                     continue  // skip normal emit while buffering or just flushed
                 }
 
+                // ── Stop sequence check BEFORE feeding the tracker ──
+                // The stop sequence itself must never reach the client, so only the
+                // slice of this chunk that survives the trim may enter the state
+                // machine. (An earlier revision fed the whole chunk first and emitted
+                // the tracker's output verbatim, which leaked the stop string and
+                // anything after it — review finding on #115. The pre-review code had
+                // the opposite bug: its arithmetic assumed everything before this chunk
+                // was already emitted, dropping text the tracker was holding.)
+                let stopHit = checkStopSequences(fullText, stopSequences: stopSequences)
+                let survivingText: String
+                if let (trimmedFull, _) = stopHit {
+                    let priorCount = fullText.count - text.count
+                    survivingText = String(text.prefix(max(0, trimmedFull.count - priorCount)))
+                } else {
+                    survivingText = text
+                }
+
                 // ── Route text through thinking state machine ──
                 let (reasoningText, contentText) = enableThinking
-                    ? tracker.process(text)
-                    : ("", text)
+                    ? tracker.process(survivingText)
+                    : ("", survivingText)
 
-                // ── Stop sequence check (operate on full accumulated text) ──
-                if let (trimmedFull, _) = checkStopSequences(fullText, stopSequences: stopSequences) {
-                    // This chunk was already fed to the tracker above; emit what that
-                    // produced rather than re-processing a slice of fullText. The old
-                    // arithmetic assumed everything before this chunk had been emitted,
-                    // which is false whenever the tracker is holding a partial tag — the
-                    // held text was then dropped instead of sent (#108).
+                if stopHit != nil {
                     if !reasoningText.isEmpty || !contentText.isEmpty {
                         cont.yield(sseChunk(modelId: modelId,
                                             reasoningContent: reasoningText.isEmpty ? nil : reasoningText,

--- a/Sources/SwiftLM/Server.swift
+++ b/Sources/SwiftLM/Server.swift
@@ -1732,12 +1732,20 @@ struct ThinkingStateTracker {
     /// the opening tag never appears in the model's own output. Comparing the last
     /// opening tag against the last closing tag distinguishes the two cases.
     static func opensUnclosedThinkingBlock(_ prompt: String) -> Bool {
-        func lastIndex(of tags: [String]) -> String.Index? {
-            tags.compactMap { prompt.range(of: $0, options: .backwards)?.lowerBound }.max()
+        func lastRange(of tags: [String]) -> Range<String.Index>? {
+            tags.compactMap { prompt.range(of: $0, options: .backwards) }
+                .max { $0.lowerBound < $1.lowerBound }
         }
-        guard let lastOpen = lastIndex(of: openTags) else { return false }
-        guard let lastClose = lastIndex(of: closeTags) else { return true }
-        return lastOpen > lastClose
+        guard let lastOpen = lastRange(of: openTags) else { return false }
+        if let lastClose = lastRange(of: closeTags), lastClose.lowerBound > lastOpen.lowerBound {
+            return false
+        }
+        // The tag must be the last thing in the prompt. A template that pre-opens always
+        // ends `…<|im_start|>assistant\n<think>\n`, whereas a `<think>` mentioned in the
+        // conversation itself is followed by more text — and treating that as pre-opened
+        // would route the model's entire answer into reasoning_content, leaving content
+        // empty (e.g. a user asking "explain the <think> tag").
+        return prompt[lastOpen.upperBound...].allSatisfy { $0.isWhitespace }
     }
 
     /// Feed the next text fragment. Returns (reasoningContent, responseContent)
@@ -1960,13 +1968,24 @@ func handleChatStreaming(
 
                 // ── Stop sequence check (operate on full accumulated text) ──
                 if let (trimmedFull, _) = checkStopSequences(fullText, stopSequences: stopSequences) {
-                    // Emit any final partial content that hasn't been sent yet
-                    let emittedSoFar = fullText.count - text.count
-                    if trimmedFull.count > emittedSoFar {
-                        let partialText = String(trimmedFull.suffix(trimmedFull.count - emittedSoFar))
-                        let (r, c) = enableThinking ? tracker.process(partialText) : ("", partialText)
-                        cont.yield(sseChunk(modelId: modelId, reasoningContent: r.isEmpty ? nil : r,
-                                            content: c.isEmpty ? nil : c, finishReason: nil))
+                    // This chunk was already fed to the tracker above; emit what that
+                    // produced rather than re-processing a slice of fullText. The old
+                    // arithmetic assumed everything before this chunk had been emitted,
+                    // which is false whenever the tracker is holding a partial tag — the
+                    // held text was then dropped instead of sent (#108).
+                    if !reasoningText.isEmpty || !contentText.isEmpty {
+                        cont.yield(sseChunk(modelId: modelId,
+                                            reasoningContent: reasoningText.isEmpty ? nil : reasoningText,
+                                            content: contentText.isEmpty ? nil : contentText,
+                                            finishReason: nil))
+                    }
+                    // Drain anything still held for a partial tag that never completed.
+                    if enableThinking {
+                        let (r, c) = tracker.flush()
+                        if !r.isEmpty || !c.isEmpty {
+                            cont.yield(sseChunk(modelId: modelId, reasoningContent: r.isEmpty ? nil : r,
+                                                content: c.isEmpty ? nil : c, finishReason: nil))
+                        }
                     }
                     cont.yield(sseChunk(modelId: modelId, reasoningContent: nil, content: nil, finishReason: "stop"))
                     let genDur = Date().timeIntervalSince(genStart)
@@ -2217,9 +2236,12 @@ func extractThinkingBlock(from text: String, alreadyOpen: Bool = false) -> (Stri
     let startTag = text.range(of: "<thinking>") ?? text.range(of: "<think>") ?? text.range(of: "<|channel>thought\n") ?? text.range(of: "<|channel>thought") ?? (text.hasPrefix("thought\n") ? text.range(of: "thought\n") : nil)
     let endTag = text.range(of: "</thinking>") ?? text.range(of: "</think>") ?? text.range(of: "<channel|>")
 
-    // Template pre-opened the block and the model did not re-emit an opening tag:
-    // treat the start of the text as the start of the reasoning.
-    if alreadyOpen, startTag == nil {
+    // Template pre-opened the block. Only a tag at the very start means the model
+    // re-emitted its own opening tag; a tag further in is the model *talking about* one
+    // from inside its reasoning, and deferring to the tag path there silently discarded
+    // everything before it. This matches the streaming tracker, which stays in the
+    // thinking phase until a closing tag.
+    if alreadyOpen, startTag.map({ $0.lowerBound != text.startIndex }) ?? true {
         guard let endRange = endTag else {
             // Still thinking when generation stopped — no response content yet.
             return (text.isEmpty ? nil : text, "")

--- a/tests/SwiftLMTests/ThinkingPreOpenedTests.swift
+++ b/tests/SwiftLMTests/ThinkingPreOpenedTests.swift
@@ -143,6 +143,12 @@ final class ThinkingPreOpenedTests: XCTestCase {
         XCTAssertEqual(c, "")
     }
 
+    /// The lastRange tie rule must not depend on openTags ordering: at the same start
+    /// position, `<thinking>` wins over its own `<think>` prefix (review finding on #115).
+    func testThinkingTagAtPromptEndDetectedRegardlessOfTagOrder() {
+        XCTAssertTrue(ThinkingStateTracker.opensUnclosedThinkingBlock("<|im_start|>assistant\n<thinking>\n"))
+    }
+
     // ═══════════════════════════════════════════════════════════════════
     // MARK: - 3. End-of-stream flush (tail truncation)
     // ═══════════════════════════════════════════════════════════════════

--- a/tests/SwiftLMTests/ThinkingPreOpenedTests.swift
+++ b/tests/SwiftLMTests/ThinkingPreOpenedTests.swift
@@ -64,6 +64,22 @@ final class ThinkingPreOpenedTests: XCTestCase {
         XCTAssertFalse(ThinkingStateTracker.opensUnclosedThinkingBlock("<|channel>thought\n<channel|>"))
     }
 
+    /// A `<think>` the *user* wrote must not be mistaken for a pre-opened block. Before
+    /// this guard, asking about the tag routed the model's entire answer into
+    /// reasoning_content and left content empty (review finding on #115).
+    func testTagMentionedInPromptIsNotPreOpened() {
+        let mentions = [
+            "explain the <think> tag<|im_end|>\n<|im_start|>assistant\n",
+            "<think> appears in Qwen templates.<|im_end|>\n<|im_start|>assistant\n",
+        ]
+        for tail in mentions {
+            XCTAssertFalse(ThinkingStateTracker.opensUnclosedThinkingBlock(tail),
+                           "a tag followed by more text is not a pre-opened block: \(tail)")
+        }
+        // Trailing whitespace after the tag is still a pre-open (the template's form).
+        XCTAssertTrue(ThinkingStateTracker.opensUnclosedThinkingBlock("<|im_start|>assistant\n<think>\n  "))
+    }
+
     // ═══════════════════════════════════════════════════════════════════
     // MARK: - 2. Streaming with a pre-opened block
     // ═══════════════════════════════════════════════════════════════════
@@ -201,6 +217,16 @@ final class ThinkingPreOpenedTests: XCTestCase {
         let (thinking, remaining) = extractThinkingBlock(from: text, alreadyOpen: true)
         XCTAssertEqual(thinking, "reasoning")
         XCTAssertEqual(remaining, "answer")
+    }
+
+    /// With the block pre-opened, a tag the model mentions *inside* its reasoning must
+    /// not cause the text before it to be discarded (review finding on #115).
+    func testExtractPreOpenedKeepsTextBeforeAMentionedTag() {
+        let text = "The user asked about <think> tags.\n</think>\nAnswer."
+        let (thinking, remaining) = extractThinkingBlock(from: text, alreadyOpen: true)
+        XCTAssertEqual(thinking, "The user asked about <think> tags.\n",
+                       "leading reasoning must not be dropped")
+        XCTAssertEqual(remaining, "Answer.")
     }
 
     /// Truncated mid-reasoning: all reasoning, no content.

--- a/tests/SwiftLMTests/ThinkingPreOpenedTests.swift
+++ b/tests/SwiftLMTests/ThinkingPreOpenedTests.swift
@@ -1,0 +1,220 @@
+import XCTest
+import Foundation
+@testable import SwiftLM
+
+// MARK: - Regression tests for Issue #108 — templates that pre-open the thinking block
+//
+// Root cause: Qwen3/3.5/3.6 chat templates append `<think>\n` to the generation prompt
+// when enable_thinking is true:
+//
+//     {%- if add_generation_prompt %}
+//         {{- '<|im_start|>assistant\n' }}
+//         {%- if enable_thinking is defined and enable_thinking is false %}
+//             {{- '<think>\n\n</think>\n\n' }}
+//         {%- else %}
+//             {{- '<think>\n' }}          <-- prompt ends inside the block
+//
+// The model therefore emits reasoning with no opening tag of its own, terminated by
+// `</think>`. ThinkingStateTracker started in .responding and extractThinkingBlock
+// required both tags, so the whole reasoning section was misfiled as response content
+// with a stray `</think>` inside it — the client never saw an opening tag, and replaying
+// that assistant turn taught the model to omit its own first line.
+//
+// Fix: detect the unclosed tag in the rendered prompt tail and start the parser inside
+// the thinking block. Also drains the tracker at end of stream so a response ending in
+// a partial-tag suffix is not truncated.
+final class ThinkingPreOpenedTests: XCTestCase {
+
+    // ═══════════════════════════════════════════════════════════════════
+    // MARK: - 1. Detecting a pre-opened block in the prompt
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// The enable_thinking=true branch of the Qwen3.6 template.
+    func testDetectsQwenOpenThinkPrompt() {
+        let tail = "<|im_start|>assistant\n<think>\n"
+        XCTAssertTrue(ThinkingStateTracker.opensUnclosedThinkingBlock(tail))
+    }
+
+    /// The enable_thinking=false branch emits an *already closed* block — the model
+    /// will produce plain content, so the parser must not start in thinking mode.
+    func testClosedThinkBlockInPromptIsNotOpen() {
+        let tail = "<|im_start|>assistant\n<think>\n\n</think>\n\n"
+        XCTAssertFalse(ThinkingStateTracker.opensUnclosedThinkingBlock(tail))
+    }
+
+    /// Templates that do not touch the thinking channel at all.
+    func testPlainPromptIsNotOpen() {
+        XCTAssertFalse(ThinkingStateTracker.opensUnclosedThinkingBlock("<|im_start|>assistant\n"))
+        XCTAssertFalse(ThinkingStateTracker.opensUnclosedThinkingBlock(""))
+    }
+
+    /// Prior turns in the prompt contain complete <think>…</think> pairs; only the
+    /// final unmatched opening tag counts.
+    func testPriorClosedBlocksDoNotConfuseDetection() {
+        let withHistory = "<|im_start|>assistant\n<think>\nold reasoning\n</think>\nold answer<|im_end|>\n<|im_start|>assistant\n<think>\n"
+        XCTAssertTrue(ThinkingStateTracker.opensUnclosedThinkingBlock(withHistory))
+
+        let historyOnly = "<|im_start|>assistant\n<think>\nold reasoning\n</think>\nold answer<|im_end|>\n<|im_start|>assistant\n"
+        XCTAssertFalse(ThinkingStateTracker.opensUnclosedThinkingBlock(historyOnly))
+    }
+
+    /// Gemma-4 channel markers use a different spelling but the same shape.
+    func testGemmaChannelMarkers() {
+        XCTAssertTrue(ThinkingStateTracker.opensUnclosedThinkingBlock("<|channel>thought\n"))
+        XCTAssertFalse(ThinkingStateTracker.opensUnclosedThinkingBlock("<|channel>thought\n<channel|>"))
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // MARK: - 2. Streaming with a pre-opened block
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// The issue's exact shape: reasoning arrives first with no opening tag.
+    /// Before the fix this landed in `content` together with a stray `</think>`.
+    func testStreamingPreOpenedRoutesReasoningCorrectly() {
+        var tracker = ThinkingStateTracker(startInThinking: true)
+        var reasoning = ""
+        var content = ""
+        for chunk in ["Okay, the user", " wants a file listing.", "\n</think>\n", "Here are your files:"] {
+            let (r, c) = tracker.process(chunk)
+            reasoning += r
+            content += c
+        }
+        let (fr, fc) = tracker.flush()
+        reasoning += fr
+        content += fc
+
+        XCTAssertEqual(reasoning, "Okay, the user wants a file listing.\n")
+        // The newline that followed the closing tag stays in content — streaming does
+        // not trim it (pre-existing behaviour, matching the self-opened path).
+        XCTAssertEqual(content, "\nHere are your files:")
+        XCTAssertFalse(content.contains("</think>"), "closing tag must never leak into content")
+    }
+
+    /// The closing tag split across chunk boundaries must still be consumed.
+    func testStreamingPreOpenedWithSplitClosingTag() {
+        var tracker = ThinkingStateTracker(startInThinking: true)
+        var reasoning = ""
+        var content = ""
+        for chunk in ["reasoning", "</", "think", ">", "answer"] {
+            let (r, c) = tracker.process(chunk)
+            reasoning += r
+            content += c
+        }
+        XCTAssertEqual(reasoning, "reasoning")
+        XCTAssertEqual(content, "answer")
+    }
+
+    /// A model that *does* emit its own opening tag (LM Studio-style, template did not
+    /// pre-open) must keep working exactly as before.
+    func testStreamingSelfOpenedUnchanged() {
+        var tracker = ThinkingStateTracker(startInThinking: false)
+        var reasoning = ""
+        var content = ""
+        for chunk in ["<think>", "thinking hard", "</think>", "the answer"] {
+            let (r, c) = tracker.process(chunk)
+            reasoning += r
+            content += c
+        }
+        XCTAssertEqual(reasoning, "thinking hard")
+        XCTAssertEqual(content, "the answer")
+    }
+
+    /// Generation cut short mid-reasoning: everything is reasoning, no content.
+    func testStreamingPreOpenedUnterminated() {
+        var tracker = ThinkingStateTracker(startInThinking: true)
+        let (r, c) = tracker.process("still thinking when we hit the token limit")
+        XCTAssertEqual(r, "still thinking when we hit the token limit")
+        XCTAssertEqual(c, "")
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // MARK: - 3. End-of-stream flush (tail truncation)
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// A response whose final characters look like the start of a tag leaves the whole
+    /// pending buffer held inside the tracker (it holds everything, not just the
+    /// ambiguous suffix). Without a flush at end of stream that text was dropped —
+    /// the response simply ended early.
+    func testFlushEmitsHeldPartialTagAsContent() {
+        var tracker = ThinkingStateTracker(startInThinking: false)
+        let (r, c) = tracker.process("the value of x <")
+        XCTAssertEqual(r, "")
+        XCTAssertEqual(c, "", "a trailing '<' holds the whole buffer pending disambiguation")
+
+        let (fr, fc) = tracker.flush()
+        XCTAssertEqual(fr, "")
+        XCTAssertEqual(fc, "the value of x <", "held text must be emitted at end of stream, not dropped")
+    }
+
+    /// Held text resolves normally when the stream continues — the flush path only
+    /// matters when generation ends while text is still buffered.
+    func testHeldTextIsReleasedWhenStreamContinues() {
+        var tracker = ThinkingStateTracker(startInThinking: false)
+        XCTAssertEqual(tracker.process("the value of x <").content, "")
+        XCTAssertEqual(tracker.process(" 3 holds").content, "the value of x < 3 holds")
+    }
+
+    /// Same, but the stream ended while inside the thinking block.
+    func testFlushEmitsHeldTextAsReasoningWhileThinking() {
+        var tracker = ThinkingStateTracker(startInThinking: true)
+        _ = tracker.process("thinking </")
+        let (fr, fc) = tracker.flush()
+        XCTAssertEqual(fr, "thinking </")
+        XCTAssertEqual(fc, "")
+    }
+
+    func testFlushIsIdempotentAndEmptyWhenNothingHeld() {
+        var tracker = ThinkingStateTracker(startInThinking: false)
+        _ = tracker.process("complete response.")
+        let first = tracker.flush()
+        XCTAssertEqual(first.reasoning, "")
+        XCTAssertEqual(first.content, "")
+        let second = tracker.flush()
+        XCTAssertEqual(second.reasoning, "")
+        XCTAssertEqual(second.content, "")
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // MARK: - 4. Non-streaming extraction
+    // ═══════════════════════════════════════════════════════════════════
+
+    func testExtractPreOpenedBlock() {
+        let text = "Let me think about this.\n</think>\nThe answer is 42."
+        let (thinking, remaining) = extractThinkingBlock(from: text, alreadyOpen: true)
+        XCTAssertEqual(thinking, "Let me think about this.\n")
+        XCTAssertEqual(remaining, "The answer is 42.")
+    }
+
+    /// Without the flag the old behaviour is preserved: no opening tag means the text
+    /// is returned as-is. This is what the client was receiving before the fix.
+    func testExtractPreOpenedBlockWithoutFlagIsUnchanged() {
+        let text = "Let me think about this.\n</think>\nThe answer is 42."
+        let (thinking, remaining) = extractThinkingBlock(from: text)
+        XCTAssertNil(thinking)
+        XCTAssertEqual(remaining, text)
+    }
+
+    /// If the model re-emits its own opening tag despite the pre-open, the tag-based
+    /// path wins and must not double-count the reasoning.
+    func testExtractPreOpenedButModelEmittedItsOwnTag() {
+        let text = "<think>reasoning</think>answer"
+        let (thinking, remaining) = extractThinkingBlock(from: text, alreadyOpen: true)
+        XCTAssertEqual(thinking, "reasoning")
+        XCTAssertEqual(remaining, "answer")
+    }
+
+    /// Truncated mid-reasoning: all reasoning, no content.
+    func testExtractPreOpenedUnterminated() {
+        let (thinking, remaining) = extractThinkingBlock(from: "unfinished reasoning", alreadyOpen: true)
+        XCTAssertEqual(thinking, "unfinished reasoning")
+        XCTAssertEqual(remaining, "")
+    }
+
+    /// A pre-opened block the model closed immediately produces no reasoning and all
+    /// content — reasoning_content must be nil rather than an empty string.
+    func testExtractPreOpenedEmptyReasoning() {
+        let (thinking, remaining) = extractThinkingBlock(from: "</think>\nstraight to the answer", alreadyOpen: true)
+        XCTAssertNil(thinking)
+        XCTAssertEqual(remaining, "straight to the answer")
+    }
+}


### PR DESCRIPTION
Fixes #108.

## Root cause

Qwen3/3.5/3.6 chat templates append `<think>\n` to the generation prompt when `enable_thinking` is true. From the cached `Qwen3.6-35B-A3B` `tokenizer_config.json`:

```jinja
{%- if add_generation_prompt %}
    {{- '<|im_start|>assistant\n' }}
    {%- if enable_thinking is defined and enable_thinking is false %}
        {{- '<think>\n\n</think>\n\n' }}
    {%- else %}
        {{- '<think>\n' }}          {# prompt ends inside the block #}
    {%- endif %}
```

The model therefore emits reasoning with **no opening tag of its own**, terminated by `</think>`. But `ThinkingStateTracker` always started in `.responding` (`Server.swift:1695`) and `extractThinkingBlock` required *both* tags (`Server.swift:2137`). So the whole reasoning section was misfiled as `content`, with a stray `</think>` inside it.

That is exactly the reported symptom — "the client doesn't get the beginning `<think>` tag" — and it explains the follow-on behaviour with tool calls: the replayed assistant turn starts mid-thought, so the model learns to omit its own first line.

The reporter noting that vllm-mlx behaves identically fits: it's the template, not MLX.

## Changes

- **Detect the pre-opened block at runtime** — decode the rendered prompt tail (32 tokens) and compare the last opening tag against the last closing tag. This is deliberately not keyed to a model family: the same Qwen line differs by version (cached `Qwen3-1.7B` does *not* pre-open, `Qwen3.6` does), so hard-coding would break on the next release.
- **`ThinkingStateTracker(startInThinking:)`** — starts the parser inside the block; `extractThinkingBlock(from:alreadyOpen:)` does the same for the non-streaming path.
- **Drain the tracker at end of stream** — a second, independent defect: a response whose final characters look like the start of a tag stayed in the buffer and was dropped. The stream loop had no flush at finish.
- Tag spellings are now shared constants, and matching picks the *earliest* match instead of preferring `<thinking>` found later in the buffer.

## Tests

New `tests/SwiftLMTests/ThinkingPreOpenedTests.swift` — 18 tests over prompt detection (both template branches, prior closed blocks in history, Gemma channel markers), streaming with a pre-opened block (including a closing tag split across chunks), the end-of-stream flush, and non-streaming extraction. `testExtractPreOpenedBlockWithoutFlagIsUnchanged` pins the old broken output so the difference is explicit.

Verified red: with `startInThinking` ignored and `flush()` stubbed to return empty, 9 of the 18 fail.

**End-to-end**, against **`mlx-community/Qwen3.5-4B-4bit`** — a real, unmodified model whose `chat_template.jinja` carries the same pre-opening form as Qwen3.6:

```jinja
{%- if enable_thinking is defined and enable_thinking is false %}
    {{- '<think>\n\n</think>\n\n' }}
{%- else %}
    {{- '<think>\n' }}
{%- endif %}
```

| case | result |
|---|---|
| `--thinking`, non-streaming | detection fires; reasoning → `reasoning_content` (461 chars), `content` = `"Tokyo"`, no leaked tags |
| `--thinking`, streaming | 148 chunks; reasoning → `reasoning_content` deltas, `content` = `"\n\n54"`, no leaked tags |
| no `--thinking` (control) | template emits an already-closed block, detection stays off, `reasoning_content` = null, `content` = `"Tokyo"` |

Also confirmed on `mlx-community/Qwen3.5-0.8B-MLX-4bit` that detection fires and reasoning is routed correctly, though that model loops without ever emitting `</think>`, so it never reaches the content phase.

Full suite: 114 tests across 9 suites, 0 failures. `PromptCacheTests` aborts under `swift test` with `Failed to load the default metallib` — pre-existing at HEAD and environmental, so suites were run individually.

## Note on scope

Streaming does not trim the newline that follows `</think>`, so `content` begins with `\n\n` (visible in the table above). That is pre-existing behaviour shared with the self-opened path — the non-streaming path does trim — and this PR leaves it alone rather than widening scope. Worth a follow-up if the inconsistency matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
