### PR TITLE
fix: detect hand-copied models in the cache root (#110)

### DIFF
--- a/Sources/MLXInferenceCore/InferenceEngine.swift
+++ b/Sources/MLXInferenceCore/InferenceEngine.swift
@@ -354,7 +354,17 @@ public final class InferenceEngine: ObservableObject {
             // loadWeights() initialises ExpertStreamerManager correctly.
             // lazyLoad=true means weights are mmap'd and not paged into RAM
             // at load time — only active expert pages touch RAM during inference.
-            var config = ModelConfiguration(id: modelId)
+            // A model the user copied in by hand does not live at the materialized
+            // `<cacheRoot>/models/<id>` path that ModelConfiguration(id:) resolves
+            // through HubApi. Recognising those layouts in the scan (issue #110) without
+            // pointing the loader at them would list the model and then re-download it —
+            // several GB for a model already on disk. Load such models by directory.
+            var config: ModelConfiguration
+            if let localDirectory = ModelStorage.localLoadDirectory(for: modelId) {
+                config = ModelConfiguration(directory: localDirectory)
+            } else {
+                config = ModelConfiguration(id: modelId)
+            }
             let isMoE = ModelCatalog.all.first(where: { $0.id == modelId })?.isMoE ?? false
             let generationConfig = GenerationConfig.load()
             if generationConfig.enableMTP {

--- a/Sources/MLXInferenceCore/ModelDownloadManager.swift
+++ b/Sources/MLXInferenceCore/ModelDownloadManager.swift
@@ -58,6 +58,9 @@ public final class ModelDownloadManager: ObservableObject {
     @Published public private(set) var networkStatus: NetworkStatus = .unknown
 
     private var downloadedModelIDs: Set<String> = []
+    /// Paths already reported by the unrecognized-directory diagnostic (issue #110),
+    /// so refreshing the models view does not reprint the same lines.
+    private var loggedUnrecognizedPaths: Set<String> = []
 
     // MARK: Persistence
     private let lastModelKey = "swiftlm.lastLoadedModelId"
@@ -142,6 +145,18 @@ public final class ModelDownloadManager: ObservableObject {
                 // Exclude models that are already actively downloading
                 !activeDownloads.keys.contains(incomplete.id)
             }
+
+        // Issue #110: a folder that looks like a model but fails verification used to
+        // vanish silently, indistinguishable from one the app never looked at. Log the
+        // reason once per distinct set so repeated refreshes stay quiet.
+        let unrecognized = ModelStorage.diagnoseUnrecognizedDirectories(knownModels: scanned)
+        let paths = Set(unrecognized.map(\.directory.path))
+        if paths != loggedUnrecognizedPaths {
+            loggedUnrecognizedPaths = paths
+            for finding in unrecognized {
+                print("[ModelStorage] Not listed: \(finding.directory.path) — \(finding.reason)")
+            }
+        }
     }
 
     public func isDownloaded(_ modelId: String) -> Bool {

--- a/Sources/MLXInferenceCore/ModelDownloadManager.swift
+++ b/Sources/MLXInferenceCore/ModelDownloadManager.swift
@@ -125,6 +125,23 @@ public final class ModelDownloadManager: ObservableObject {
 
     // MARK: — Storage
 
+    /// Re-scan off the main actor, then publish on it.
+    ///
+    /// `refresh()` walks every model directory recursively (integrity, size, incomplete
+    /// files, diagnostics). That is seconds of work on a large cache, and the models view
+    /// calls it on every appearance, so it must not run on the main actor (issue #110
+    /// review).
+    public func refreshInBackground() {
+        Task.detached(priority: .utility) { [weak self] in
+            let scanned = ModelStorage.scanDownloadedModels()
+            let incomplete = ModelStorage.scanIncompleteDownloads()
+            let unrecognized = ModelStorage.diagnoseUnrecognizedDirectories(knownModels: scanned)
+            await MainActor.run {
+                self?.apply(scanned: scanned, incomplete: incomplete, unrecognized: unrecognized)
+            }
+        }
+    }
+
     /// Re-scan the cache and update published state.
     public func refresh() {
         let scanned = ModelStorage.scanDownloadedModels()
@@ -149,13 +166,34 @@ public final class ModelDownloadManager: ObservableObject {
         // Issue #110: a folder that looks like a model but fails verification used to
         // vanish silently, indistinguishable from one the app never looked at. Log the
         // reason once per distinct set so repeated refreshes stay quiet.
-        let unrecognized = ModelStorage.diagnoseUnrecognizedDirectories(knownModels: scanned)
+        logUnrecognized(ModelStorage.diagnoseUnrecognizedDirectories(knownModels: scanned))
+    }
+
+    private func apply(
+        scanned: [ModelStorage.ScannedModel],
+        incomplete: [ModelStorage.IncompleteDownload],
+        unrecognized: [(directory: URL, reason: String)]
+    ) {
+        downloadedModels = scanned.map { s in
+            DownloadedModel(
+                id: s.modelId,
+                cacheDirectory: s.cacheDirectory,
+                sizeBytes: s.sizeBytes,
+                modifiedDate: s.modifiedDate
+            )
+        }
+        downloadedModelIDs = Set(downloadedModels.map(\.id))
+        totalDiskUsageBytes = downloadedModels.reduce(0) { $0 + $1.sizeBytes }
+        incompleteDownloads = incomplete.filter { !activeDownloads.keys.contains($0.id) }
+        logUnrecognized(unrecognized)
+    }
+
+    private func logUnrecognized(_ unrecognized: [(directory: URL, reason: String)]) {
         let paths = Set(unrecognized.map(\.directory.path))
-        if paths != loggedUnrecognizedPaths {
-            loggedUnrecognizedPaths = paths
-            for finding in unrecognized {
-                print("[ModelStorage] Not listed: \(finding.directory.path) — \(finding.reason)")
-            }
+        guard paths != loggedUnrecognizedPaths else { return }
+        loggedUnrecognizedPaths = paths
+        for finding in unrecognized {
+            print("[ModelStorage] Not listed: \(finding.directory.path) — \(finding.reason)")
         }
     }
 

--- a/Sources/MLXInferenceCore/ModelStorage.swift
+++ b/Sources/MLXInferenceCore/ModelStorage.swift
@@ -81,8 +81,12 @@ public enum ModelStorage {
     /// compare strings: an id of `"models/"`, `"/models"` or `"./models"` all reduce to
     /// `<cacheRoot>/models`, and `".."` components escape the root entirely.
     static func isSafeModelDirectory(_ url: URL) -> Bool {
-        let root = cacheRoot.standardizedFileURL
-        let candidate = url.standardizedFileURL
+        // Resolve symlinks on both sides: standardizedFileURL alone is lexical, so a
+        // symlink component under the root could point anywhere and still look like a
+        // descendant. Resolving both sides keeps the comparison in one namespace
+        // (/var vs /private/var) and lets the descendant check see the real target.
+        let root = cacheRoot.resolvingSymlinksInPath().standardizedFileURL
+        let candidate = url.resolvingSymlinksInPath().standardizedFileURL
         let rootComponents = root.pathComponents
         let candidateComponents = candidate.pathComponents
 
@@ -91,9 +95,15 @@ public enum ModelStorage {
             Array(candidateComponents.prefix(rootComponents.count)) == rootComponents
         else { return false }
 
-        // Never the shared layout wrapper itself.
-        let relative = candidateComponents.dropFirst(rootComponents.count)
-        if relative.count == 1 && relative.first == "models" { return false }
+        // Never the shared layout wrapper or anything directly inside it that is not a
+        // concrete model (i.e. the wrapper itself or an org directory). macOS APFS is
+        // case-insensitive by default, so "Models" and "models" are the same directory
+        // while == on the strings is not — a case-sensitive compare here let
+        // delete("Models") wipe every downloaded model (review finding on #116).
+        let relative = Array(candidateComponents.dropFirst(rootComponents.count))
+        let isWrapperName =
+            relative[0].compare("models", options: [.caseInsensitive]) == .orderedSame
+        if isWrapperName && relative.count < 3 { return false }
         return true
     }
 
@@ -400,7 +410,7 @@ public enum ModelStorage {
                     .replacingOccurrences(of: "^models--", with: "", options: .regularExpression)
                     .replacingOccurrences(of: "--", with: "/")
                 addScannedModelIfDownloaded(modelId: modelId, dir: dir, resultsById: &resultsById)
-            } else if dir.lastPathComponent == "models" {
+            } else if dir.lastPathComponent.compare("models", options: [.caseInsensitive]) == .orderedSame {
                 guard let organizations = try? FileManager.default.contentsOfDirectory(
                     at: dir,
                     includingPropertiesForKeys: [.contentModificationDateKey],
@@ -565,7 +575,7 @@ public enum ModelStorage {
                     .replacingOccurrences(of: "^models--", with: "", options: .regularExpression)
                     .replacingOccurrences(of: "--", with: "/")
                 addIncompleteDownloadIfNeeded(modelId: modelId, dir: dir, resultsById: &resultsById)
-            } else if dir.lastPathComponent == "models" {
+            } else if dir.lastPathComponent.compare("models", options: [.caseInsensitive]) == .orderedSame {
                 guard let organizations = try? FileManager.default.contentsOfDirectory(
                     at: dir,
                     includingPropertiesForKeys: [.contentModificationDateKey],

--- a/Sources/MLXInferenceCore/ModelStorage.swift
+++ b/Sources/MLXInferenceCore/ModelStorage.swift
@@ -8,8 +8,9 @@ public enum ModelStorage {
 
     // MARK: — Platform Paths
 
-    /// Test hook: when set, overrides `cacheRoot` entirely.
-    nonisolated(unsafe) public static var cacheRootOverride: URL?
+    /// Test hook: when set, overrides `cacheRoot` entirely. Deliberately not public —
+    /// tests reach it through `@testable import`.
+    nonisolated(unsafe) static var cacheRootOverride: URL?
 
     /// Root directory where model files are stored on this platform.
     /// This is the `downloadBase` passed to `HubApi`.
@@ -59,18 +60,41 @@ public enum ModelStorage {
     /// A model folder copied straight into the cache root, with no `models--` prefix
     /// and no `snapshots/` level — e.g. `<cacheRoot>/Qwen3.5-27B-oQ6/` or
     /// `<cacheRoot>/mlx-community/Qwen3.5-27B-oQ6/` (issue #110).
-    public static func plainDirectory(for modelId: String) -> URL? {
-        // An empty or "models" id would resolve to the cache root / hub layout root,
-        // which must never be treated as a model directory (delete() walks these).
-        guard !modelId.isEmpty, modelId != "models" else { return nil }
-        let dir = plainDirectoryURL(for: modelId)
+    static func plainDirectory(for modelId: String) -> URL? {
+        guard let dir = plainDirectoryURL(for: modelId) else { return nil }
         return directoryExists(dir) ? dir : nil
     }
 
-    private static func plainDirectoryURL(for modelId: String) -> URL {
-        modelId.split(separator: "/").reduce(cacheRoot) { url, component in
+    private static func plainDirectoryURL(for modelId: String) -> URL? {
+        let url = modelId.split(separator: "/").reduce(cacheRoot) { url, component in
             url.appendingPathComponent(String(component), isDirectory: true)
         }
+        return isSafeModelDirectory(url) ? url : nil
+    }
+
+    /// Whether a URL is a location a model may legitimately occupy, i.e. a strict
+    /// descendant of the cache root that is neither the root itself nor the shared
+    /// `models/` wrapper.
+    ///
+    /// `delete()` calls `FileManager.removeItem` on the directories associated with an
+    /// id, so this is a destructive-action guard and must resolve the path rather than
+    /// compare strings: an id of `"models/"`, `"/models"` or `"./models"` all reduce to
+    /// `<cacheRoot>/models`, and `".."` components escape the root entirely.
+    static func isSafeModelDirectory(_ url: URL) -> Bool {
+        let root = cacheRoot.standardizedFileURL
+        let candidate = url.standardizedFileURL
+        let rootComponents = root.pathComponents
+        let candidateComponents = candidate.pathComponents
+
+        // Must be strictly below the cache root, by at least one component.
+        guard candidateComponents.count > rootComponents.count,
+            Array(candidateComponents.prefix(rootComponents.count)) == rootComponents
+        else { return false }
+
+        // Never the shared layout wrapper itself.
+        let relative = candidateComponents.dropFirst(rootComponents.count)
+        if relative.count == 1 && relative.first == "models" { return false }
+        return true
     }
 
     /// Swift Hub's materialized repository directory.
@@ -146,6 +170,17 @@ public enum ModelStorage {
             (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
         }
         return directories.count == 1 ? directories[0] : nil
+    }
+
+    /// The directory to load a model from when it does not live at the materialized
+    /// `<cacheRoot>/models/<id>` path that `HubApi` resolves, i.e. when the user copied
+    /// it in by hand or it came from `huggingface-cli`. Returns nil when the standard
+    /// path applies, so callers keep the normal id-based flow (and its download
+    /// behaviour) for everything else.
+    public static func localLoadDirectory(for modelId: String) -> URL? {
+        guard materializedDirectory(for: modelId) == nil else { return nil }
+        guard isDownloaded(modelId) else { return nil }
+        return modelContentDirectories(for: modelId).first
     }
 
     public static func isDownloaded(_ modelId: String) -> Bool {
@@ -612,6 +647,11 @@ public enum ModelStorage {
         if let plain = plainDirectory(for: modelId) {
             candidates.append(plain)
         }
+        // Every path here is a removeItem target. An empty id makes
+        // appendingPathComponent("") a no-op, so materializedDirectoryURL(for: "")
+        // resolves to the shared `models/` wrapper and would delete every downloaded
+        // model; the same guard covers `..` escapes on any of the three layouts.
+        candidates = candidates.filter { isSafeModelDirectory($0) }
 
         var seen = Set<String>()
         return candidates.filter { url in

--- a/Sources/MLXInferenceCore/ModelStorage.swift
+++ b/Sources/MLXInferenceCore/ModelStorage.swift
@@ -1,5 +1,5 @@
 // ModelStorage.swift — Platform-aware model storage resolution
-// macOS: ~/Library/Caches/huggingface/hub/  (same as defaultHubApi)
+// macOS: ~/.cache/huggingface/hub/ (or $HF_HUB_CACHE / $HF_HOME/hub — same as huggingface-cli)
 // iOS:   ~/Library/Application Support/SwiftBuddy/Models/ (persistent, excluded from iCloud)
 
 import Foundation
@@ -8,12 +8,22 @@ public enum ModelStorage {
 
     // MARK: — Platform Paths
 
+    /// Test hook: when set, overrides `cacheRoot` entirely.
+    nonisolated(unsafe) public static var cacheRootOverride: URL?
+
     /// Root directory where model files are stored on this platform.
     /// This is the `downloadBase` passed to `HubApi`.
     public static var cacheRoot: URL {
+        if let cacheRootOverride { return cacheRootOverride }
         #if os(macOS)
-        // macOS: Single source of truth with Python (huggingface-cli / mlx_lm)
-        if let hfHome = ProcessInfo.processInfo.environment["HF_HOME"] {
+        // macOS: Single source of truth with Python (huggingface-cli / mlx_lm).
+        // Precedence matches huggingface_hub: HF_HUB_CACHE points at the hub
+        // directory itself, HF_HOME at its parent.
+        let environment = ProcessInfo.processInfo.environment
+        if let hubCache = environment["HF_HUB_CACHE"], !hubCache.isEmpty {
+            return URL(fileURLWithPath: hubCache)
+        }
+        if let hfHome = environment["HF_HOME"], !hfHome.isEmpty {
             return URL(fileURLWithPath: hfHome).appendingPathComponent("hub")
         }
         return FileManager.default.homeDirectoryForCurrentUser
@@ -43,7 +53,24 @@ public enum ModelStorage {
 
     /// Local cache directory for a model, or nil if not downloaded.
     public static func cacheDirectory(for modelId: String) -> URL? {
-        materializedDirectory(for: modelId) ?? hubCacheDirectory(for: modelId)
+        materializedDirectory(for: modelId) ?? hubCacheDirectory(for: modelId) ?? plainDirectory(for: modelId)
+    }
+
+    /// A model folder copied straight into the cache root, with no `models--` prefix
+    /// and no `snapshots/` level — e.g. `<cacheRoot>/Qwen3.5-27B-oQ6/` or
+    /// `<cacheRoot>/mlx-community/Qwen3.5-27B-oQ6/` (issue #110).
+    public static func plainDirectory(for modelId: String) -> URL? {
+        // An empty or "models" id would resolve to the cache root / hub layout root,
+        // which must never be treated as a model directory (delete() walks these).
+        guard !modelId.isEmpty, modelId != "models" else { return nil }
+        let dir = plainDirectoryURL(for: modelId)
+        return directoryExists(dir) ? dir : nil
+    }
+
+    private static func plainDirectoryURL(for modelId: String) -> URL {
+        modelId.split(separator: "/").reduce(cacheRoot) { url, component in
+            url.appendingPathComponent(String(component), isDirectory: true)
+        }
     }
 
     /// Swift Hub's materialized repository directory.
@@ -74,11 +101,14 @@ public enum ModelStorage {
         return FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) && isDirectory.boolValue
     }
 
-    /// True if a model's cache directory exists and contains files.
-    // The snapshot directory is where safetensors files live inside the HF hub layout:
-    // <cacheRoot>/models--org--name/snapshots/main/
+    /// The directory holding a model's weight files.
+    ///
+    /// Resolves through every supported layout — see `scanDownloadedModels()` — and
+    /// only falls back to the canonical hub path when none of them exist. Returning a
+    /// path that does not exist would silently misconfigure consumers such as SSD
+    /// expert streaming, which points its reader at this directory.
     public static func snapshotDirectory(for modelId: String) -> URL {
-        return materializedDirectory(for: modelId) ?? resolvedSnapshotDirectory(for: modelId) ?? cacheRoot
+        modelContentDirectories(for: modelId).first ?? cacheRoot
             .appendingPathComponent(hubDirName(for: modelId))
             .appendingPathComponent("snapshots/main")
     }
@@ -173,12 +203,18 @@ public enum ModelStorage {
 
     private static func modelContentDirectories(for modelId: String) -> [URL] {
         var directories: [URL] = []
-        if let materialized = materializedDirectory(for: modelId) {
-            directories.append(materialized)
+        func append(_ url: URL?) {
+            guard let url, !directories.contains(url) else { return }
+            directories.append(url)
         }
-        if let snapshot = resolvedSnapshotDirectory(for: modelId), !directories.contains(snapshot) {
-            directories.append(snapshot)
-        }
+
+        append(materializedDirectory(for: modelId))
+        append(resolvedSnapshotDirectory(for: modelId))
+        // Issue #110: a `models--org--name` folder copied by hand often holds the
+        // weights directly, with no `snapshots/<hash>/` level for the HF cache layout.
+        append(hubCacheDirectory(for: modelId))
+        // …and a folder copied in without the `models--` prefix at all.
+        append(plainDirectory(for: modelId))
         return directories
     }
 
@@ -302,7 +338,17 @@ public enum ModelStorage {
     }
 
     /// Scan the cache root and return all recognizable downloaded models.
-    /// Only returns models present in `ModelCatalog.all`.
+    ///
+    /// Recognised layouts, all rooted at `cacheRoot`:
+    ///   - `models--org--name/snapshots/<hash>/`  — the huggingface-cli cache layout
+    ///   - `models--org--name/`                   — the same folder copied by hand,
+    ///                                              weights sitting directly inside
+    ///   - `models/org/name/`                     — Swift Hub's materialized layout
+    ///   - `org/name/` or `name/`                 — a model folder copied straight in
+    ///
+    /// The last two forms exist because users copy model folders into the cache by
+    /// hand and expect them to appear (issue #110). Directories that look like a model
+    /// but fail verification are reported by `diagnoseUnrecognizedDirectories()`.
     public static func scanDownloadedModels() -> [ScannedModel] {
         guard FileManager.default.fileExists(atPath: cacheRoot.path),
               let contents = try? FileManager.default.contentsOfDirectory(
@@ -338,9 +384,91 @@ public enum ModelStorage {
                         addScannedModelIfDownloaded(modelId: modelId, dir: modelDir, resultsById: &resultsById)
                     }
                 }
+            } else if directoryExists(dir) {
+                // Hand-copied folder: either the model itself, or an org directory
+                // holding one (issue #110).
+                let name = dir.lastPathComponent
+                if containsModelConfig(dir) {
+                    addScannedModelIfDownloaded(modelId: name, dir: dir, resultsById: &resultsById)
+                } else {
+                    let children = (try? FileManager.default.contentsOfDirectory(
+                        at: dir,
+                        includingPropertiesForKeys: [.contentModificationDateKey],
+                        options: [.skipsHiddenFiles]
+                    )) ?? []
+                    for child in children where directoryExists(child) && containsModelConfig(child) {
+                        addScannedModelIfDownloaded(
+                            modelId: "\(name)/\(child.lastPathComponent)",
+                            dir: child,
+                            resultsById: &resultsById
+                        )
+                    }
+                }
             }
         }
         return resultsById.values.sorted { ($0.modifiedDate ?? .distantPast) > ($1.modifiedDate ?? .distantPast) }
+    }
+
+    /// A directory holding a model's own files (as opposed to a cache wrapper).
+    private static func containsModelConfig(_ directory: URL) -> Bool {
+        FileManager.default.fileExists(atPath: directory.appendingPathComponent("config.json").path)
+    }
+
+    /// Directories under the cache root that look like a model but were not returned
+    /// by `scanDownloadedModels()`, paired with the reason each was rejected.
+    ///
+    /// Without this, a model the app refuses to list is indistinguishable from one it
+    /// never looked at — which is what made issue #110 hard to diagnose.
+    /// - Parameter knownModels: the result of a `scanDownloadedModels()` the caller
+    ///   already performed; omit to run a fresh scan.
+    public static func diagnoseUnrecognizedDirectories(
+        knownModels: [ScannedModel]? = nil
+    ) -> [(directory: URL, reason: String)] {
+        // Compare canonical paths: contentsOfDirectory resolves symlinks (/var →
+        // /private/var) while cacheDirectory builds paths from cacheRoot verbatim,
+        // so raw string comparison would report every valid model as unrecognized.
+        let recognized = Set((knownModels ?? scanDownloadedModels()).map { canonicalPath($0.cacheDirectory) })
+        guard let contents = try? FileManager.default.contentsOfDirectory(
+            at: cacheRoot,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+
+        var findings: [(directory: URL, reason: String)] = []
+        for dir in contents where directoryExists(dir) && dir.lastPathComponent != "models" {
+            let candidates = containsModelConfig(dir)
+                ? [dir]
+                : ((try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])) ?? [])
+                    .filter { directoryExists($0) && containsModelConfig($0) }
+
+            for candidate in candidates where !recognized.contains(canonicalPath(candidate)) {
+                findings.append((candidate, rejectionReason(for: candidate)))
+            }
+        }
+        return findings
+    }
+
+    private static func canonicalPath(_ url: URL) -> String {
+        url.resolvingSymlinksInPath().standardizedFileURL.path
+    }
+
+    private static func rejectionReason(for directory: URL) -> String {
+        if countIncompleteFiles(in: directory) > 0 {
+            return "contains .incomplete files — finish or delete the partial download"
+        }
+        let indexPath = directory.appendingPathComponent("model.safetensors.index.json")
+        let hasIndex = FileManager.default.fileExists(atPath: indexPath.path)
+        let single = directory.appendingPathComponent("model.safetensors")
+        let hasSingle = (fileSizeResolvingSymlink(single) ?? 0) > 1024
+        if !hasIndex && !hasSingle {
+            let shards = (try? FileManager.default.contentsOfDirectory(atPath: directory.path))?
+                .filter { $0.hasSuffix(".safetensors") } ?? []
+            if shards.isEmpty {
+                return "no .safetensors weights found (GGUF and .npz models are not supported)"
+            }
+            return "sharded weights present but model.safetensors.index.json is missing"
+        }
+        return "weight files missing or truncated relative to model.safetensors.index.json"
     }
 
     private static func addScannedModelIfDownloaded(
@@ -475,10 +603,15 @@ public enum ModelStorage {
     // MARK: — Helpers
 
     private static func associatedDirectories(for modelId: String) -> [URL] {
-        let candidates = [
+        var candidates = [
             materializedDirectoryURL(for: modelId),
             hubCacheDirectoryURL(for: modelId),
         ]
+        // Only a hand-copied folder that actually exists — plainDirectoryURL for an
+        // unknown id can point at an unrelated directory, and delete() walks this list.
+        if let plain = plainDirectory(for: modelId) {
+            candidates.append(plain)
+        }
 
         var seen = Set<String>()
         return candidates.filter { url in

--- a/SwiftBuddy/SwiftBuddy/Views/ModelsView.swift
+++ b/SwiftBuddy/SwiftBuddy/Views/ModelsView.swift
@@ -200,6 +200,10 @@ struct ModelsView: View {
                 }
             }
         }
+        // Issue #110: refresh() previously ran only at init, after a download, and
+        // after a delete — so a model folder copied into the cache while the app was
+        // open stayed invisible until the next launch.
+        .onAppear { dm.refresh() }
         .sheet(isPresented: $showHFSearch) {
             HFSearchSheet(onSelect: handleSelect)
                 .environmentObject(engine)

--- a/SwiftBuddy/SwiftBuddy/Views/ModelsView.swift
+++ b/SwiftBuddy/SwiftBuddy/Views/ModelsView.swift
@@ -203,7 +203,7 @@ struct ModelsView: View {
         // Issue #110: refresh() previously ran only at init, after a download, and
         // after a delete — so a model folder copied into the cache while the app was
         // open stayed invisible until the next launch.
-        .onAppear { dm.refresh() }
+        .onAppear { dm.refreshInBackground() }
         .sheet(isPresented: $showHFSearch) {
             HFSearchSheet(onSelect: handleSelect)
                 .environmentObject(engine)

--- a/tests/SwiftBuddyTests/ModelStorageLayoutTests.swift
+++ b/tests/SwiftBuddyTests/ModelStorageLayoutTests.swift
@@ -231,14 +231,40 @@ final class ModelStorageLayoutTests: XCTestCase {
 
     // MARK: - 6. Deletion safety
 
-    /// delete() walks the directories associated with an id. A bogus id must not
-    /// resolve to the cache root or the shared `models/` wrapper.
-    func testPlainDirectoryNeverResolvesToCacheRootOrModelsWrapper() throws {
+    /// delete() calls removeItem on every directory associated with an id, so a bogus id
+    /// must never resolve to the cache root or the shared `models/` wrapper. The earlier
+    /// version of this test only checked plainDirectory's return value and never called
+    /// delete(), so it passed even while `delete("models/")` wiped the whole tree.
+    func testDeleteWithHostileIdsLeavesTheCacheIntact() throws {
         try makeModel(at: "models/mlx-community/Qwen3-4B-4bit")
+        try makeModel(at: "models/mlx-community/Qwen3-8B-4bit")
+        try makeModel(at: "HandCopied")
+        let survivors = [
+            root.appendingPathComponent("models/mlx-community/Qwen3-4B-4bit"),
+            root.appendingPathComponent("models/mlx-community/Qwen3-8B-4bit"),
+            root.appendingPathComponent("HandCopied"),
+        ]
 
-        XCTAssertNil(ModelStorage.plainDirectory(for: ""))
-        XCTAssertNil(ModelStorage.plainDirectory(for: "models"))
-        XCTAssertTrue(FileManager.default.fileExists(atPath: root.path))
+        // Each of these reduces to the cache root or the `models/` wrapper.
+        for hostile in ["", "models", "models/", "/models", "models//", "./models", "..", "../..", "a/.."] {
+            try? ModelStorage.delete(hostile)
+            XCTAssertTrue(FileManager.default.fileExists(atPath: root.path),
+                          "cache root removed by delete(\"\(hostile)\")")
+            for survivor in survivors {
+                XCTAssertTrue(FileManager.default.fileExists(atPath: survivor.path),
+                              "delete(\"\(hostile)\") removed \(survivor.lastPathComponent)")
+            }
+        }
+        XCTAssertEqual(scannedIds().count, 3, "no model should have been deleted")
+    }
+
+    func testIsSafeModelDirectoryRejectsRootAndWrapper() {
+        XCTAssertFalse(ModelStorage.isSafeModelDirectory(root))
+        XCTAssertFalse(ModelStorage.isSafeModelDirectory(root.appendingPathComponent("models")))
+        XCTAssertFalse(ModelStorage.isSafeModelDirectory(root.appendingPathComponent("..")))
+        XCTAssertFalse(ModelStorage.isSafeModelDirectory(root.deletingLastPathComponent()))
+        XCTAssertTrue(ModelStorage.isSafeModelDirectory(root.appendingPathComponent("SomeModel")))
+        XCTAssertTrue(ModelStorage.isSafeModelDirectory(root.appendingPathComponent("models/org/name")))
     }
 
     func testDeleteRemovesHandCopiedFolder() throws {

--- a/tests/SwiftBuddyTests/ModelStorageLayoutTests.swift
+++ b/tests/SwiftBuddyTests/ModelStorageLayoutTests.swift
@@ -245,8 +245,12 @@ final class ModelStorageLayoutTests: XCTestCase {
             root.appendingPathComponent("HandCopied"),
         ]
 
-        // Each of these reduces to the cache root or the `models/` wrapper.
-        for hostile in ["", "models", "models/", "/models", "models//", "./models", "..", "../..", "a/.."] {
+        // Each of these reduces to the cache root or the `models/` wrapper. The case
+        // variants matter because APFS is case-insensitive by default: "Models" and
+        // "models" are the same directory while a string compare says otherwise
+        // (review finding on #116). "models/mlx-community" guards a whole org.
+        for hostile in ["", "models", "models/", "/models", "models//", "./models", "..", "../..", "a/..",
+                        "Models", "MODELS", "Models/", "models/mlx-community"] {
             try? ModelStorage.delete(hostile)
             XCTAssertTrue(FileManager.default.fileExists(atPath: root.path),
                           "cache root removed by delete(\"\(hostile)\")")
@@ -261,6 +265,9 @@ final class ModelStorageLayoutTests: XCTestCase {
     func testIsSafeModelDirectoryRejectsRootAndWrapper() {
         XCTAssertFalse(ModelStorage.isSafeModelDirectory(root))
         XCTAssertFalse(ModelStorage.isSafeModelDirectory(root.appendingPathComponent("models")))
+        XCTAssertFalse(ModelStorage.isSafeModelDirectory(root.appendingPathComponent("Models")))
+        XCTAssertFalse(ModelStorage.isSafeModelDirectory(root.appendingPathComponent("MODELS")))
+        XCTAssertFalse(ModelStorage.isSafeModelDirectory(root.appendingPathComponent("models/mlx-community")))
         XCTAssertFalse(ModelStorage.isSafeModelDirectory(root.appendingPathComponent("..")))
         XCTAssertFalse(ModelStorage.isSafeModelDirectory(root.deletingLastPathComponent()))
         XCTAssertTrue(ModelStorage.isSafeModelDirectory(root.appendingPathComponent("SomeModel")))

--- a/tests/SwiftBuddyTests/ModelStorageLayoutTests.swift
+++ b/tests/SwiftBuddyTests/ModelStorageLayoutTests.swift
@@ -1,0 +1,262 @@
+import XCTest
+import Foundation
+@testable import MLXInferenceCore
+
+// MARK: - Regression tests for Issue #110 — hand-copied models are not detected
+//
+// The scan only accepted `models--org--name/snapshots/<hash>/` and the Swift Hub
+// `models/org/name/` layout. A user who copies a model folder into the cache root —
+// with no `models--` prefix, or with the weights sitting directly inside the
+// `models--org--name` folder and no `snapshots/` level — got a model the app silently
+// refused to list, with no indication why.
+//
+// These tests build real directory trees under a temporary cache root (via
+// ModelStorage.cacheRootOverride) and lock in every layout the scan accepts, plus the
+// rejection diagnostics.
+final class ModelStorageLayoutTests: XCTestCase {
+
+    private var root: URL!
+
+    override func setUpWithError() throws {
+        root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("swiftlm-storage-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        ModelStorage.cacheRootOverride = root
+    }
+
+    override func tearDownWithError() throws {
+        ModelStorage.cacheRootOverride = nil
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    // MARK: Fixtures
+
+    /// Writes a minimally valid single-file model (config.json + a >1KB safetensors).
+    @discardableResult
+    private func makeModel(at relativePath: String, weightBytes: Int = 4096) throws -> URL {
+        let dir = root.appendingPathComponent(relativePath, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try #"{"model_type":"qwen3","num_hidden_layers":28}"#
+            .write(to: dir.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+        try Data(repeating: 0x7, count: weightBytes)
+            .write(to: dir.appendingPathComponent("model.safetensors"))
+        return dir
+    }
+
+    private func scannedIds() -> [String] {
+        ModelStorage.scanDownloadedModels().map(\.modelId).sorted()
+    }
+
+    // MARK: - 1. Layouts that already worked (must not regress)
+
+    func testHubCacheLayoutWithSnapshot() throws {
+        try makeModel(at: "models--mlx-community--Qwen3-8B-4bit/snapshots/abc123")
+        try "abc123".write(
+            to: root.appendingPathComponent("models--mlx-community--Qwen3-8B-4bit/refs/main")
+                .creatingParent(),
+            atomically: true, encoding: .utf8)
+
+        XCTAssertEqual(scannedIds(), ["mlx-community/Qwen3-8B-4bit"])
+        XCTAssertTrue(ModelStorage.isDownloaded("mlx-community/Qwen3-8B-4bit"))
+    }
+
+    func testMaterializedModelsLayout() throws {
+        try makeModel(at: "models/mlx-community/Qwen3-4B-4bit")
+        XCTAssertEqual(scannedIds(), ["mlx-community/Qwen3-4B-4bit"])
+        XCTAssertTrue(ModelStorage.isDownloaded("mlx-community/Qwen3-4B-4bit"))
+    }
+
+    // MARK: - 2. Hand-copied layouts (issue #110)
+
+    /// The `models--org--name` folder copied by hand, weights directly inside and no
+    /// `snapshots/` level at all.
+    func testHubPrefixedFolderWithoutSnapshots() throws {
+        try makeModel(at: "models--mlx-community--Qwen3.5-27B-oQ6")
+
+        XCTAssertEqual(scannedIds(), ["mlx-community/Qwen3.5-27B-oQ6"])
+        XCTAssertTrue(ModelStorage.isDownloaded("mlx-community/Qwen3.5-27B-oQ6"))
+        XCTAssertNotNil(ModelStorage.readModelConfig(for: "mlx-community/Qwen3.5-27B-oQ6"))
+    }
+
+    /// A bare model folder dropped into the cache root, no org level.
+    func testPlainFolderWithoutOrganization() throws {
+        try makeModel(at: "Qwen3.5-27B-oQ6")
+
+        XCTAssertEqual(scannedIds(), ["Qwen3.5-27B-oQ6"])
+        XCTAssertTrue(ModelStorage.isDownloaded("Qwen3.5-27B-oQ6"))
+    }
+
+    /// An `org/name` pair copied in without the `models--` mangling.
+    func testPlainOrganizationAndNameFolder() throws {
+        try makeModel(at: "mlx-community/Qwen3.5-27B-oQ6")
+
+        XCTAssertEqual(scannedIds(), ["mlx-community/Qwen3.5-27B-oQ6"])
+        XCTAssertTrue(ModelStorage.isDownloaded("mlx-community/Qwen3.5-27B-oQ6"))
+    }
+
+    func testShardedHandCopiedModelWithIndex() throws {
+        let dir = root.appendingPathComponent("mlx-community/Qwen3-32B-4bit", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try #"{"model_type":"qwen3"}"#
+            .write(to: dir.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+        for shard in ["model-00001-of-00002.safetensors", "model-00002-of-00002.safetensors"] {
+            try Data(repeating: 0x7, count: 4096).write(to: dir.appendingPathComponent(shard))
+        }
+        let index = """
+        {"metadata":{"total_size":8192},"weight_map":{\
+        "a":"model-00001-of-00002.safetensors","b":"model-00002-of-00002.safetensors"}}
+        """
+        try index.write(to: dir.appendingPathComponent("model.safetensors.index.json"),
+                        atomically: true, encoding: .utf8)
+
+        XCTAssertEqual(scannedIds(), ["mlx-community/Qwen3-32B-4bit"])
+    }
+
+    // MARK: - 3. Things that must still be rejected
+
+    func testIncompleteDownloadIsNotListed() throws {
+        let dir = try makeModel(at: "mlx-community/Qwen3-8B-4bit")
+        try Data(repeating: 0, count: 16)
+            .write(to: dir.appendingPathComponent("model.safetensors.incomplete"))
+
+        XCTAssertEqual(scannedIds(), [])
+        XCTAssertFalse(ModelStorage.isDownloaded("mlx-community/Qwen3-8B-4bit"))
+    }
+
+    func testFolderWithoutWeightsIsNotListed() throws {
+        let dir = root.appendingPathComponent("mlx-community/NoWeights", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try #"{"model_type":"qwen3"}"#
+            .write(to: dir.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+
+        XCTAssertEqual(scannedIds(), [])
+    }
+
+    func testUnrelatedDirectoriesAreIgnored() throws {
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent(".locks/models--x"), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("random-notes"), withIntermediateDirectories: true)
+        try "not a model".write(to: root.appendingPathComponent("random-notes/todo.txt"),
+                                atomically: true, encoding: .utf8)
+
+        XCTAssertEqual(scannedIds(), [])
+        XCTAssertTrue(ModelStorage.diagnoseUnrecognizedDirectories().isEmpty,
+                      "directories with no config.json are not model candidates")
+    }
+
+    // MARK: - 4. Diagnostics
+
+    func testDiagnosticsExplainMissingWeights() throws {
+        let dir = root.appendingPathComponent("mlx-community/BrokenModel", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try #"{"model_type":"qwen3"}"#
+            .write(to: dir.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+
+        let findings = ModelStorage.diagnoseUnrecognizedDirectories()
+        XCTAssertEqual(findings.count, 1)
+        XCTAssertEqual(findings.first?.directory.lastPathComponent, "BrokenModel")
+        XCTAssertTrue(findings.first?.reason.contains("no .safetensors weights") == true,
+                      "got: \(findings.first?.reason ?? "nil")")
+    }
+
+    func testDiagnosticsExplainMissingIndex() throws {
+        let dir = root.appendingPathComponent("ShardedNoIndex", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try #"{"model_type":"qwen3"}"#
+            .write(to: dir.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+        try Data(repeating: 0x7, count: 4096)
+            .write(to: dir.appendingPathComponent("model-00001-of-00002.safetensors"))
+
+        let findings = ModelStorage.diagnoseUnrecognizedDirectories()
+        XCTAssertEqual(findings.count, 1)
+        XCTAssertTrue(findings.first?.reason.contains("index.json is missing") == true,
+                      "got: \(findings.first?.reason ?? "nil")")
+    }
+
+    func testDiagnosticsExplainIncompleteFiles() throws {
+        let dir = try makeModel(at: "mlx-community/Partial")
+        try Data(repeating: 0, count: 16)
+            .write(to: dir.appendingPathComponent("model.safetensors.incomplete"))
+
+        let findings = ModelStorage.diagnoseUnrecognizedDirectories()
+        XCTAssertEqual(findings.count, 1)
+        XCTAssertTrue(findings.first?.reason.contains(".incomplete") == true,
+                      "got: \(findings.first?.reason ?? "nil")")
+    }
+
+    /// A model the scan *does* accept must never be reported as unrecognized.
+    func testDiagnosticsAreSilentForValidModels() throws {
+        try makeModel(at: "mlx-community/Qwen3-8B-4bit")
+        try makeModel(at: "PlainCopy")
+
+        XCTAssertEqual(scannedIds(), ["PlainCopy", "mlx-community/Qwen3-8B-4bit"])
+        let findings = ModelStorage.diagnoseUnrecognizedDirectories()
+        XCTAssertTrue(findings.isEmpty,
+                      "got: \(findings.map { "\($0.directory.path): \($0.reason)" })")
+    }
+
+    // MARK: - 5. snapshotDirectory resolution
+    //
+    // SSD expert streaming points its reader at snapshotDirectory(), so a path that
+    // does not exist misconfigures streaming rather than failing loudly.
+
+    func testSnapshotDirectoryResolvesForEveryLayout() throws {
+        let cases: [(path: String, id: String)] = [
+            ("models--mlx-community--WithSnapshot/snapshots/abc", "mlx-community/WithSnapshot"),
+            ("models/mlx-community/Materialized", "mlx-community/Materialized"),
+            ("models--mlx-community--NoSnapshots", "mlx-community/NoSnapshots"),
+            ("mlx-community/PlainOrg", "mlx-community/PlainOrg"),
+            ("PlainBare", "PlainBare"),
+        ]
+        for testCase in cases {
+            try makeModel(at: testCase.path)
+        }
+
+        for testCase in cases {
+            let resolved = ModelStorage.snapshotDirectory(for: testCase.id)
+            XCTAssertTrue(
+                FileManager.default.fileExists(atPath: resolved.appendingPathComponent("config.json").path),
+                "\(testCase.id) resolved to \(resolved.path), which holds no config.json")
+        }
+    }
+
+    /// With nothing on disk the legacy hub path is still returned, so callers that
+    /// construct a download destination keep working.
+    func testSnapshotDirectoryFallsBackToHubPathWhenAbsent() {
+        let resolved = ModelStorage.snapshotDirectory(for: "mlx-community/NotThere")
+        XCTAssertEqual(resolved.path,
+                       root.appendingPathComponent("models--mlx-community--NotThere/snapshots/main").path)
+    }
+
+    // MARK: - 6. Deletion safety
+
+    /// delete() walks the directories associated with an id. A bogus id must not
+    /// resolve to the cache root or the shared `models/` wrapper.
+    func testPlainDirectoryNeverResolvesToCacheRootOrModelsWrapper() throws {
+        try makeModel(at: "models/mlx-community/Qwen3-4B-4bit")
+
+        XCTAssertNil(ModelStorage.plainDirectory(for: ""))
+        XCTAssertNil(ModelStorage.plainDirectory(for: "models"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: root.path))
+    }
+
+    func testDeleteRemovesHandCopiedFolder() throws {
+        let dir = try makeModel(at: "mlx-community/Qwen3.5-27B-oQ6")
+        XCTAssertTrue(ModelStorage.isDownloaded("mlx-community/Qwen3.5-27B-oQ6"))
+
+        try ModelStorage.delete("mlx-community/Qwen3.5-27B-oQ6")
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: dir.path))
+        XCTAssertEqual(scannedIds(), [])
+    }
+}
+
+private extension URL {
+    /// Creates the parent directory of this URL and returns the URL unchanged.
+    func creatingParent() -> URL {
+        try? FileManager.default.createDirectory(
+            at: deletingLastPathComponent(), withIntermediateDirectories: true)
+        return self
+    }
+}


### PR DESCRIPTION
Fixes #110.

## Root cause

`ModelStorage.scanDownloadedModels()` accepted only two layouts under the cache root:

- `models--org--name/snapshots/<hash>/` — the huggingface-cli cache layout, which additionally needs `refs/main`, a `snapshots/main`, or exactly one snapshot directory to resolve
- `models/org/name/` — Swift Hub's materialized layout

Copying a model folder in by hand produces neither. The folder was skipped by the scan entirely, or reached `isDownloaded()` and failed because `resolvedSnapshotDirectory()` returned nil — either way it silently did not appear, with nothing logged to say why.

## Changes

**Accept the layouts users actually produce.** In addition to the two above:

- `models--org--name/` with the weights directly inside and no `snapshots/` level
- `org/name/` or a bare `name/` folder copied straight into the cache root

**Honour `HF_HUB_CACHE`.** Only `HF_HOME` was read. Precedence now matches `huggingface_hub`: `HF_HUB_CACHE` (the hub directory itself), then `HF_HOME/hub`, then `~/.cache/huggingface/hub`.

**Fix `snapshotDirectory()`.** It returned a synthesised `…/snapshots/main` path that does not exist for a hand-copied model. `InferenceEngine.swift:370` hands that path to SSD expert streaming, so a detected-but-unresolvable model would have misconfigured the streaming reader instead of failing loudly. It now resolves through every supported layout and falls back to the hub path only when nothing exists.

**Explain rejections.** `diagnoseUnrecognizedDirectories()` reports folders that contain a `config.json` but did not make it into the scan, with the reason — missing weights, sharded weights with no `model.safetensors.index.json`, or leftover `.incomplete` files. `ModelDownloadManager.refresh()` logs these once per distinct set, so repeated refreshes stay quiet.

**Rescan on view appear.** `refresh()` ran only at init, after a download, and after a delete. A folder copied in while the app was open stayed invisible until relaunch.

**Deletion safety.** `delete()` walks the directories associated with an id, so a hand-copied path is included only when it actually exists, and an empty or `"models"` id can no longer resolve to the cache root or the layout wrapper. Covered by tests.

Also corrects two stale comments: the file header named `~/Library/Caches/huggingface/hub` (wrong directory), and `scanDownloadedModels()` claimed to filter by `ModelCatalog.all`, which it does not do.

## Tests

New `tests/SwiftBuddyTests/ModelStorageLayoutTests.swift` — 17 tests building real directory trees under a temporary cache root (`ModelStorage.cacheRootOverride`, added as a test hook): every accepted layout including sharded, the rejections that must stay rejected, the diagnostic reasons, `snapshotDirectory` resolution per layout, and deletion safety.

Also verified against a **real 622MB model folder** copied into a cache root exactly as the report describes (`cp -RL <snapshot> <hub>/Qwen3.5-0.8B-oQ6`): detected at the right size, `config.json` readable, max context length parsed, `snapshotDirectory` resolving to the copied folder, and no spurious diagnostics.

Full suite: 129 tests across 10 suites, 0 failures. `PromptCacheTests` and `ModelLifecycleTests` abort under `swift test` with `Failed to load the default metallib` — reproduced at HEAD without these changes, so pre-existing and environmental; suites were run individually.

## What is not verified here

The fix is verified at the `ModelStorage` layer, not through the SwiftBuddy UI — loading a model end-to-end in a test needs the Metal library the test bundle cannot find. The reporter's exact directory layout is also still unknown; this covers the plausible shapes rather than a confirmed one, and the new diagnostics mean the next such report arrives with the reason attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)