### PR TITLE
ci: make model prefetch fail loudly instead of stalling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        modality: [server, vision, audio, graph, omni, opencode]
+        # `models` is prefetched before the test runs. Without it the SwiftLM server
+        # downloads the model itself inside the test's 180 s startup window, which the
+        # 4.9 GB gemma-4 builds cannot make (audio/omni/opencode). Keep in sync with the
+        # model each tests/test-<modality>.sh actually loads.
+        include:
+          - modality: server
+            models: mlx-community/Qwen2.5-0.5B-Instruct-4bit
+          - modality: vision
+            models: mlx-community/Qwen2-VL-2B-Instruct-4bit
+          - modality: audio
+            models: mlx-community/gemma-4-e4b-it-4bit
+          - modality: graph
+            models: ""
+          - modality: omni
+            models: mlx-community/gemma-4-e4b-it-4bit
+          - modality: opencode
+            models: mlx-community/gemma-4-e4b-it-4bit
     steps:
       - uses: actions/checkout@v4
         with:
@@ -95,12 +111,34 @@ jobs:
       - name: Restore Architecture Privileges
         run: chmod +x .build/release/SwiftLM
 
-      - name: Cache MLX model
+      # The key is per-modality and derived from the test script, so changing the model a
+      # test loads rotates the key automatically. The previous static
+      # `mlx-model-qwen2.5-0.5b-4bit` key could never be re-saved once created
+      # (actions/cache does not overwrite an existing key), so the gemma-4 modalities kept
+      # restoring a cache that had never contained their model.
+      - name: Cache MLX models (${{ matrix.modality }})
         uses: actions/cache@v4
         with:
           path: ~/.cache/huggingface
-          key: mlx-model-qwen2.5-0.5b-4bit
-          
+          key: hf-models-v2-${{ matrix.modality }}-${{ hashFiles(format('tests/test-{0}.sh', matrix.modality)) }}
+          restore-keys: |
+            hf-models-v2-${{ matrix.modality }}-
+
+      - name: Set up HuggingFace CLI
+        if: matrix.models != ''
+        run: |
+          python3 -m venv /tmp/hf_venv
+          /tmp/hf_venv/bin/pip install --quiet huggingface_hub hf
+
+      - name: Pre-download models (${{ matrix.modality }})
+        if: matrix.models != ''
+        env:
+          HF_HUB_DOWNLOAD_TIMEOUT: "60"
+        run: |
+          source /tmp/hf_venv/bin/activate
+          chmod +x scripts/ci-download-models.sh
+          scripts/ci-download-models.sh ${{ matrix.models }}
+
       - name: Run E2E tests (${{ matrix.modality }})
         env:
           HF_HUB_DOWNLOAD_TIMEOUT: "600"
@@ -183,13 +221,17 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/huggingface
-          key: mlx-speculative-qwen35-2b-0.8b
+          key: mlx-speculative-qwen35-2b-0.8b-v2
 
       - name: Pre-download HuggingFace models
+        env:
+          HF_HUB_DOWNLOAD_TIMEOUT: "60"
         run: |
           source /tmp/mlx_venv/bin/activate
-          hf download mlx-community/Qwen3.5-2B-4bit || true
-          hf download mlx-community/Qwen3.5-0.8B-MLX-4bit || true
+          chmod +x scripts/ci-download-models.sh
+          scripts/ci-download-models.sh \
+            mlx-community/Qwen3.5-2B-4bit \
+            mlx-community/Qwen3.5-0.8B-MLX-4bit
 
       - name: Run speculative decoding E2E
         env:
@@ -277,13 +319,17 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/huggingface
-          key: mlx-dflash-qwen35-4b
+          key: mlx-dflash-qwen35-4b-v2
 
       - name: Pre-download HuggingFace models
+        env:
+          HF_HUB_DOWNLOAD_TIMEOUT: "60"
         run: |
           source /tmp/mlx_venv/bin/activate
-          hf download mlx-community/Qwen3.5-4B-4bit || true
-          hf download z-lab/Qwen3.5-4B-DFlash || true
+          chmod +x scripts/ci-download-models.sh
+          scripts/ci-download-models.sh \
+            mlx-community/Qwen3.5-4B-4bit \
+            z-lab/Qwen3.5-4B-DFlash
 
       - name: Run DFlash E2E
         env:
@@ -374,13 +420,17 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/huggingface
-          key: mlx-speculative-eval-qwen35-2b-0.8b
+          key: mlx-speculative-eval-qwen35-2b-0.8b-v2
 
       - name: Pre-download HuggingFace models
+        env:
+          HF_HUB_DOWNLOAD_TIMEOUT: "60"
         run: |
           source /tmp/mlx_venv/bin/activate
-          hf download mlx-community/Qwen3.5-2B-4bit || true
-          hf download mlx-community/Qwen3.5-0.8B-MLX-4bit || true
+          chmod +x scripts/ci-download-models.sh
+          scripts/ci-download-models.sh \
+            mlx-community/Qwen3.5-2B-4bit \
+            mlx-community/Qwen3.5-0.8B-MLX-4bit
 
       - name: Snapshot RAM before test
         id: ram_before
@@ -495,13 +545,17 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/huggingface
-          key: mlx-ssd-draft-guard-qwen35-2b-0.8b
+          key: mlx-ssd-draft-guard-qwen35-2b-0.8b-v2
 
       - name: Pre-download models
+        env:
+          HF_HUB_DOWNLOAD_TIMEOUT: "60"
         run: |
           source /tmp/mlx_venv/bin/activate
-          hf download mlx-community/Qwen3.5-2B-4bit || true
-          hf download mlx-community/Qwen3.5-0.8B-MLX-4bit || true
+          chmod +x scripts/ci-download-models.sh
+          scripts/ci-download-models.sh \
+            mlx-community/Qwen3.5-2B-4bit \
+            mlx-community/Qwen3.5-0.8B-MLX-4bit
 
       - name: Snapshot RAM baseline
         id: ram_base

--- a/scripts/ci-download-models.sh
+++ b/scripts/ci-download-models.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# ci-download-models.sh — fetch HuggingFace models for CI, with retries and verification.
+#
+# Why this exists: the prefetch steps used to be `hf download <repo> || true`, which
+# swallowed every failure. A stalled or partial download then surfaced much later as a
+# weight-loading error ("Key ... not found", "Mismatched parameter ... shape") or as the
+# server exceeding the test's 180 s startup window while it downloaded the model itself.
+#
+# Two guards:
+#   1. HF_HUB_DOWNLOAD_TIMEOUT bounds each request, so a connection the server drops
+#      (observed as sockets stuck in CLOSE_WAIT with 0 bytes moving) fails instead of
+#      hanging until the job timeout.
+#   2. Leftover *.incomplete files are treated as failure, so a half-downloaded model is
+#      never handed to the tests — and never saved into the actions/cache entry.
+#
+# Usage: ci-download-models.sh <repo> [<repo> ...]
+
+set -uo pipefail
+
+: "${HF_HUB_DOWNLOAD_TIMEOUT:=60}"
+export HF_HUB_DOWNLOAD_TIMEOUT
+
+ATTEMPTS="${CI_DOWNLOAD_ATTEMPTS:-3}"
+HUB_DIR="${HF_HUB_CACHE:-${HF_HOME:-$HOME/.cache/huggingface}/hub}"
+
+has_partial_files() {
+    local dir="$1"
+    [ -d "$dir" ] || return 1
+    find "$dir" -name '*.incomplete' -print -quit 2>/dev/null | grep -q .
+}
+
+download_one() {
+    local repo="$1"
+    local dir="$HUB_DIR/models--${repo//\//--}"
+
+    for attempt in $(seq 1 "$ATTEMPTS"); do
+        echo "--- $repo (attempt $attempt/$ATTEMPTS, per-request timeout ${HF_HUB_DOWNLOAD_TIMEOUT}s)"
+        if hf download "$repo"; then
+            if has_partial_files "$dir"; then
+                echo "::warning::$repo downloaded but .incomplete files remain; retrying"
+            else
+                echo "--- $repo OK"
+                return 0
+            fi
+        else
+            echo "::warning::$repo download failed on attempt $attempt"
+        fi
+        # Resume picks up from the existing .incomplete blobs on the next attempt.
+        sleep $(( attempt * 10 ))
+    done
+
+    echo "::error::failed to download $repo after $ATTEMPTS attempts"
+    if [ -d "$dir" ]; then
+        echo "Partial state left in $dir:"
+        find "$dir" -name '*.incomplete' -exec ls -lh {} + 2>/dev/null | head -10
+    fi
+    return 1
+}
+
+status=0
+for repo in "$@"; do
+    download_one "$repo" || status=1
+done
+
+if [ "$status" -ne 0 ]; then
+    echo "::error::one or more models could not be downloaded — failing early rather than"
+    echo "::error::letting the test suite load partial weights or time out on a cold download."
+fi
+exit "$status"


### PR DESCRIPTION
Fixes the integration failures currently red on #114, #115 and #116. None of them are caused by those PRs — all three touch disjoint files and reproduce the identical four failures, so the problem is the pipeline.

## What was failing

| modality | model it loads | status |
|---|---|---|
| server | `Qwen2.5-0.5B-Instruct-4bit` | pass |
| vision | `Qwen2-VL-2B-Instruct-4bit` | pass |
| graph | none | pass |
| **audio / omni / opencode** | **`gemma-4-e4b-it-4bit` (~4.9 GB)** | **fail** |

The three failing modalities are exactly the three that need the large model. Their errors:

```
Error: Mismatched parameter language_model.model.per_layer_model_projection.weight … Actual [10752, 320], expected [10752, 2560]
Error: Key language_model.model.layers.24.self_attn.k_proj.weight not found
Error: Server failed to start or respond on port 15413 within 180 seconds.
```

The missing key *changes between retries inside a single job* — `k_proj`, then `v_proj`, then `k_norm`. That is a file growing underneath the loader, not a model-definition bug.

`dflash` fails differently but from the same cause; its log shows the download frozen:

```
Download: [=>    ]  10% (2919.3 MB / 29193.2 MB) | Speed: 0.0 MB/s
Download: [===>  ]  20% (2919.3 MB / 14596.6 MB) | Speed: 0.0 MB/s
```

Byte count pinned, the total recomputed against a moving fraction, 0.0 MB/s throughout.

## Root causes

**1. `integration_matrix` had no prefetch step.** The server downloaded the model itself inside the test's 180 s startup window. 0.5 B and 2 B make it; 4.9 GB does not.

**2. The cache key could never be refreshed.** It was the static `mlx-model-qwen2.5-0.5b-4bit` — named for a model only one modality uses. `actions/cache` does not overwrite an existing key, so once that entry was created it was frozen: the gemma-4 jobs kept restoring a cache that had never held their model.

**3. `hf download <repo> || true` swallowed every failure**, and `HF_HUB_DOWNLOAD_TIMEOUT` was set on the test step but not on the download. An unbounded request can hang forever — I reproduced exactly this locally while fetching a model for #108: sockets stuck in `CLOSE_WAIT`, zero bytes for more than ten minutes, no timeout to break it, process alive at 0% CPU.

## Changes

- **`scripts/ci-download-models.sh`** — retries with backoff, bounds each request via `HF_HUB_DOWNLOAD_TIMEOUT` (resume continues from existing `.incomplete` blobs), treats leftover `.incomplete` files as failure, and exits non-zero so a partial model never reaches the tests or gets saved into the cache.
- **`integration_matrix`** — per-modality prefetch driven by a matrix `include`, so each job fetches exactly what its test script loads.
- **Cache keys** — per-modality and derived from the test script via `hashFiles`, so changing a test's model rotates the key automatically; `restore-keys` still allows reuse. The four static keys in the other jobs are bumped to `-v2` to drop any entry poisoned by a partial download.
- Every prefetch step now calls the script rather than `|| true`.

## Verification

The script was exercised locally on all four paths:

| case | expected | result |
|---|---|---|
| already-cached model | exit 0, fast | ✅ |
| unknown repo | exit 1, `::error::` | ✅ |
| planted `.incomplete` file | exit 1, rejected as partial | ✅ |
| multi-model invocation | each repo reported | ✅ |

`ci.yml` parses, and the matrix resolves to the six modalities with the right model each.

## What this does not fix

If the gemma-4 weight errors turn out to be a genuine model-definition mismatch rather than a truncated download, this will surface it as a clean, reproducible failure instead of one that varies per retry. That is the point — the current setup cannot tell the two apart.

I cannot run this pipeline locally, so the proof is in the next CI run on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)