### PR TITLE
ci: build the app arm64-only so releases ship again

### DIFF
--- a/.github/workflows/build-dmg.yml
+++ b/.github/workflows/build-dmg.yml
@@ -31,6 +31,7 @@ jobs:
             -scheme SwiftBuddy \
             -destination "generic/platform=macOS" \
             -configuration Release \
+            ARCHS=arm64 ONLY_ACTIVE_ARCH=NO \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_ENTITLEMENTS="" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,7 @@ jobs:
             -scheme SwiftBuddy \
             -destination "generic/platform=macOS" \
             -configuration Release \
+            ARCHS=arm64 ONLY_ACTIVE_ARCH=NO \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_ENTITLEMENTS="" \


### PR DESCRIPTION
The Release and Build-DMG workflows have failed on **every run since 2026-05-13**:

```
error: static method 'zeros(_:type:stream:)' requires that 'Float16' conform to 'HasDType'
```

No release binary has shipped in almost three months — users are still on b648, which is why #112 was reported against it. Every fix merged this week is invisible to release-binary users until this lands.

## Cause

Both workflows build SwiftBuddy with `xcodebuild -destination "generic/platform=macOS"`, which defaults to a **universal** (arm64 + x86_64) build. `Float16: HasDType` does not hold on x86_64, and a `Float16` usage added to mlx-swift-lm's `SwitchLayers.swift:1004` in mid-May made the x86_64 slice fail to compile — last green run May 8, first red May 13.

CI proper never caught it: `build_and_unit_test` uses plain `swift build`, which is arm64-only. Reproduced locally with `swift build --triple x86_64-apple-macosx14.0` (same error, same line).

## Fix

Pin `ARCHS=arm64 ONLY_ACTIVE_ARCH=NO` in both `xcodebuild` invocations. MLX requires Apple Silicon, so the x86_64 slice was never functional — it only had to compile, and now it doesn't have to.

## Verification

Ran the exact workflow command locally (generate_xcodeproj → xcodebuild with the new flags, unsigned, same TARGET_BUILD_DIR shape): **BUILD SUCCEEDED**.

Note: `release.yml` is `workflow_dispatch`-gated, so the real proof needs a manual dispatch after merge — the DMG workflow will also run automatically on the next `SwiftBuddy/**` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)