### PR TITLE
fix: decode rope_theta from nested rope_parameters (#121)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -117,7 +117,7 @@ let package = Package(
         ),
         .testTarget(
             name: "SwiftLMTests",
-            dependencies: ["SwiftLM", "MLXInferenceCore"]
+            dependencies: ["SwiftLM", "MLXInferenceCore", "DFlash"]
         )
     ]
 )

--- a/Sources/DFlash/DFlashDraftModel.swift
+++ b/Sources/DFlash/DFlashDraftModel.swift
@@ -83,6 +83,59 @@ public struct DFlashDraftConfiguration: Codable, Sendable {
             case maskTokenId = "mask_token_id"
         }
     }
+
+    /// Newer checkpoints nest rope settings under `rope_parameters` instead of flat
+    /// top-level keys (transformers' migration); `z-lab/Qwen3.5-4B-DFlash` ships only
+    /// the nested form, so requiring flat `rope_theta` failed the whole decode with
+    /// keyNotFound and the draft model never loaded (issue #121).
+    private struct RopeParameters: Codable, Sendable {
+        var ropeTheta: Float?
+
+        enum CodingKeys: String, CodingKey {
+            case ropeTheta = "rope_theta"
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        // Synthesized Codable treats every listed key as required regardless of the
+        // property defaults above; decodeIfPresent restores their intended meaning.
+        modelType = try c.decodeIfPresent(String.self, forKey: .modelType) ?? modelType
+        hiddenSize = try c.decodeIfPresent(Int.self, forKey: .hiddenSize) ?? hiddenSize
+        numHiddenLayers = try c.decodeIfPresent(Int.self, forKey: .numHiddenLayers) ?? numHiddenLayers
+        intermediateSize = try c.decodeIfPresent(Int.self, forKey: .intermediateSize) ?? intermediateSize
+        numAttentionHeads = try c.decodeIfPresent(Int.self, forKey: .numAttentionHeads) ?? numAttentionHeads
+        rmsNormEps = try c.decodeIfPresent(Float.self, forKey: .rmsNormEps) ?? rmsNormEps
+        vocabularySize = try c.decodeIfPresent(Int.self, forKey: .vocabularySize) ?? vocabularySize
+        numKeyValueHeads = try c.decodeIfPresent(Int.self, forKey: .numKeyValueHeads) ?? numKeyValueHeads
+        maxPositionEmbeddings =
+            try c.decodeIfPresent(Int.self, forKey: .maxPositionEmbeddings) ?? maxPositionEmbeddings
+        headDim = try c.decodeIfPresent(Int.self, forKey: .headDim) ?? headDim
+        tieWordEmbeddings = try c.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings) ?? tieWordEmbeddings
+        numTargetLayers = try c.decodeIfPresent(Int.self, forKey: .numTargetLayers) ?? numTargetLayers
+        blockSize = try c.decodeIfPresent(Int.self, forKey: .blockSize) ?? blockSize
+        attentionBias = try c.decodeIfPresent(Bool.self, forKey: .attentionBias) ?? attentionBias
+        attentionDropout = try c.decodeIfPresent(Float.self, forKey: .attentionDropout) ?? attentionDropout
+        ropeScaling = try c.decodeIfPresent([String: StringOrNumber].self, forKey: .ropeScaling)
+        layerTypes = try c.decodeIfPresent([String].self, forKey: .layerTypes) ?? layerTypes
+        dflashConfig = try c.decodeIfPresent(DFlashConfig.self, forKey: .dflashConfig)
+
+        // rope_theta: flat key first (older checkpoints), then rope_parameters.rope_theta.
+        if let flat = try c.decodeIfPresent(Float.self, forKey: .ropeTheta) {
+            ropeTheta = flat
+        } else {
+            let extended = try decoder.container(keyedBy: ExtendedCodingKeys.self)
+            if let nested = try extended.decodeIfPresent(RopeParameters.self, forKey: .ropeParameters),
+                let theta = nested.ropeTheta
+            {
+                ropeTheta = theta
+            }
+        }
+    }
+
+    private enum ExtendedCodingKeys: String, CodingKey {
+        case ropeParameters = "rope_parameters"
+    }
 }
 
 // MARK: - Helper: build target layer IDs

--- a/tests/SwiftLMTests/DFlashConfigDecodingTests.swift
+++ b/tests/SwiftLMTests/DFlashConfigDecodingTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+import Foundation
+@testable import DFlash
+
+// MARK: - Regression tests for Issue #121 — rope_theta moved into rope_parameters
+//
+// z-lab/Qwen3.5-4B-DFlash ships no top-level rope_theta; the value lives under
+// rope_parameters.rope_theta (transformers' rope-settings migration). The synthesized
+// Codable init treated every listed key as required — property defaults never apply to
+// synthesized decoding — so the whole config failed with keyNotFound("rope_theta") and
+// the draft model never loaded. This kept the dflash-speculative-decoding CI job red.
+final class DFlashConfigDecodingTests: XCTestCase {
+
+    /// The verbatim config.json of z-lab/Qwen3.5-4B-DFlash (fetched 2026-08-06).
+    private let realConfig = #"""
+{
+  "architectures": [
+    "DFlashDraftModel"
+  ],
+  "attention_bias": false,
+  "attention_dropout": 0.0,
+  "auto_map": {
+    "AutoModel": "dflash.DFlashDraftModel"
+  },
+  "bos_token_id": null,
+  "dflash_config": {
+    "block_size": 16,
+    "mask_token_id": 248077,
+    "target_layer_ids": [
+      1,
+      5,
+      9,
+      13,
+      17,
+      21,
+      25,
+      29
+    ]
+  },
+  "dtype": "bfloat16",
+  "eos_token_id": 248044,
+  "head_dim": 128,
+  "hidden_act": "silu",
+  "hidden_size": 2560,
+  "initializer_range": 0.02,
+  "intermediate_size": 9216,
+  "layer_types": [
+    "sliding_attention",
+    "sliding_attention",
+    "sliding_attention",
+    "sliding_attention",
+    "sliding_attention",
+    "full_attention"
+  ],
+  "max_position_embeddings": 262144,
+  "max_window_layers": 6,
+  "model_type": "qwen3",
+  "num_attention_heads": 32,
+  "num_hidden_layers": 6,
+  "num_key_value_heads": 8,
+  "num_target_layers": 32,
+  "pad_token_id": null,
+  "rms_norm_eps": 1e-06,
+  "rope_parameters": {
+    "rope_theta": 10000000,
+    "rope_type": "default"
+  },
+  "sliding_window": 4096,
+  "tie_word_embeddings": true,
+  "transformers_version": "5.7.0",
+  "use_cache": true,
+  "use_sliding_window": true,
+  "vocab_size": 248320
+}
+"""#
+
+    func testRealDFlashConfigDecodes() throws {
+        let c = try JSONDecoder().decode(
+            DFlashDraftConfiguration.self, from: Data(realConfig.utf8))
+        XCTAssertEqual(c.ropeTheta, 10_000_000, "must come from rope_parameters.rope_theta")
+        XCTAssertEqual(c.numHiddenLayers, 6)
+        XCTAssertEqual(c.blockSize, 16)
+        XCTAssertEqual(c.numTargetLayers, 32)
+    }
+
+    /// Older checkpoints with the flat key keep working.
+    func testFlatRopeThetaStillWins() throws {
+        let json = #"{"rope_theta": 5000000, "rope_parameters": {"rope_theta": 1}}"#
+        let c = try JSONDecoder().decode(DFlashDraftConfiguration.self, from: Data(json.utf8))
+        XCTAssertEqual(c.ropeTheta, 5_000_000, "flat key takes precedence when present")
+    }
+
+    /// With neither form present, the documented default applies — previously any
+    /// missing listed key failed the decode outright.
+    func testAbsentKeysFallBackToDefaults() throws {
+        let c = try JSONDecoder().decode(DFlashDraftConfiguration.self, from: Data("{}".utf8))
+        XCTAssertEqual(c.ropeTheta, 1_000_000)
+        XCTAssertEqual(c.numHiddenLayers, 4)
+    }
+}


### PR DESCRIPTION
Fixes #121 — the sole cause of the permanently red `dflash-speculative-decoding` CI job.

## Cause

`z-lab/Qwen3.5-4B-DFlash` ships no top-level `rope_theta`; the value lives under `rope_parameters.rope_theta` (transformers' rope-settings migration):

```json
"rope_parameters": { "rope_theta": 10000000, "rope_type": "default" }
```

`DFlashDraftConfiguration` relied on synthesized `Codable`, which treats **every** listed key as required — the property defaults (`var ropeTheta: Float = 1_000_000.0`) never apply to synthesized decoding. So the entire config decode failed with `keyNotFound("rope_theta")` and the draft model never loaded.

## Fix

A custom `init(from:)` restores the intended optional-with-default semantics for every field, and resolves `rope_theta` as: flat key first (older checkpoints) → `rope_parameters.rope_theta` → the 1e6 default.

## Verification

- New `tests/SwiftLMTests/DFlashConfigDecodingTests.swift` decodes the **verbatim** `z-lab/Qwen3.5-4B-DFlash` config (embedded in the test): `ropeTheta = 10_000_000`, layers/blockSize/targetLayers all correct.
- Flat-key precedence and the all-defaults case are pinned.
- **Verified red**: with the decoder reverted, all three tests fail on the original `keyNotFound`.

`Sources/SwiftLM/DeepseekV3DFlash.swift:74` declares the same flat key and may need the same treatment if a nested-form DeepSeek DFlash checkpoint appears; left out of scope since no such checkpoint is in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)