### PR TITLE
ci: gate releases on CI, and cover the checkpoint CI could not see

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,13 @@ jobs:
         include:
           - modality: server
             models: mlx-community/Qwen2.5-0.5B-Instruct-4bit
+          # Same smoke test, KV-shared Gemma 4. e2b ships k_proj/v_proj for its shared
+          # layers while e4b omits them, so it exercises a weight layout no other job
+          # covers — a regression that broke it entirely still passed CI and shipped.
+          - modality: server
+            name_suffix: -gemma-e2b
+            models: mlx-community/gemma-4-e2b-it-4bit
+            test_model: mlx-community/gemma-4-e2b-it-4bit
           - modality: vision
             models: mlx-community/Qwen2-VL-2B-Instruct-4bit
           - modality: audio
@@ -120,9 +127,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/huggingface
-          key: hf-models-v2-${{ matrix.modality }}-${{ hashFiles(format('tests/test-{0}.sh', matrix.modality)) }}
+          key: hf-models-v2-${{ matrix.modality }}${{ matrix.name_suffix }}-${{ hashFiles(format('tests/test-{0}.sh', matrix.modality)) }}
           restore-keys: |
-            hf-models-v2-${{ matrix.modality }}-
+            hf-models-v2-${{ matrix.modality }}${{ matrix.name_suffix }}-
 
       - name: Set up HuggingFace CLI
         if: matrix.models != ''
@@ -139,9 +146,10 @@ jobs:
           chmod +x scripts/ci-download-models.sh
           scripts/ci-download-models.sh ${{ matrix.models }}
 
-      - name: Run E2E tests (${{ matrix.modality }})
+      - name: Run E2E tests (${{ matrix.modality }}${{ matrix.name_suffix }})
         env:
           HF_HUB_DOWNLOAD_TIMEOUT: "600"
+          SWIFTLM_TEST_MODEL: ${{ matrix.test_model }}
         run: |
           chmod +x tests/test-${{ matrix.modality }}.sh
           for attempt in 1 2 3; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,18 @@
 name: Release
 
-# Auto-release on every push to main (like llama.cpp)
+# Auto-release after CI passes on main.
+#
+# This used to trigger directly on push, which meant the release built and published
+# concurrently with CI Pipeline and did not depend on it — a red pipeline still shipped a
+# binary. workflow_run defers the release until CI Pipeline has concluded, and the job
+# guard below requires that conclusion to be success.
+#
+# To be clear about what this does not fix: b674 shipped a Gemma 4 regression while CI
+# was green on that commit, because no job loads gemma-4-e2b-it-4bit. Gating stops a
+# release when CI fails; it cannot stop one when CI passes on an untested path.
+#
+# Note CI Pipeline concludes success when only the opencode integration job fails, since
+# that job is continue-on-error — so the known runner OOM there does not block releases.
 on:
   workflow_dispatch:
     inputs:
@@ -8,21 +20,11 @@ on:
         description: 'Create new release'
         required: true
         type: boolean
-  push:
+  workflow_run:
+    workflows: ["CI Pipeline"]
+    types: [completed]
     branches:
       - main
-    paths:
-      - '**/*.swift'
-      - '**/*.c'
-      - '**/*.cpp'
-      - '**/*.h'
-      - '**/*.hpp'
-      - '**/*.m'
-      - '**/*.mm'
-      - '**/*.metal'
-      - 'Package.swift'
-      - 'Package.resolved'
-      - '.github/workflows/release.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -34,15 +36,44 @@ permissions:
 jobs:
   build-and-release:
     runs-on: macos-15
+    # A manual dispatch always runs; an automatic one only after CI succeeded.
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.workflow_run.conclusion == 'success'
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Full history for build number
           submodules: recursive
+          # Build exactly the commit CI validated. workflow_run would otherwise check out
+          # the branch tip, which may already have moved on to an untested commit.
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
       - name: Install Metal Toolchain
         run: xcodebuild -downloadComponent MetalToolchain || true
+
+      # workflow_run carries no path filter, so the old `paths:` list is enforced here.
+      # Without this a docs-only commit would publish a release, because CI runs on every
+      # push to main. Submodule pointer moves count as source: the mlx-swift-lm bump is
+      # how the Gemma 4 fix reached users.
+      - name: Check for source changes since the last release
+        id: changes
+        run: |
+          LAST_TAG="$(git tag --list 'b[0-9]*' --sort=-creatordate | head -1)"
+          if [ -z "$LAST_TAG" ]; then
+            echo "No previous release tag; treating as source change."
+            echo "source=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          CHANGED="$(git diff --name-only "$LAST_TAG"..HEAD || true)"
+          echo "Changed since $LAST_TAG:"; echo "$CHANGED" | head -40
+          if echo "$CHANGED" | grep -qE '\.(swift|c|cpp|h|hpp|m|mm|metal)$|^Package\.(swift|resolved)$|^\.github/workflows/release\.yml$|^mlx-swift(-lm)?$'; then
+            echo "source=true" >> $GITHUB_OUTPUT
+          else
+            echo "No source changes since $LAST_TAG — build will run, publish will be skipped."
+            echo "source=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Determine tag name
         id: tag
@@ -169,7 +200,9 @@ jobs:
           RELEASE_EOF
 
       - name: Create release
-        if: ${{ github.event_name == 'push' || github.event.inputs.create_release == 'true' }}
+        if: >-
+          ${{ (github.event_name == 'workflow_run' && steps.changes.outputs.source == 'true')
+          || github.event.inputs.create_release == 'true' }}
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.tag.outputs.name }}

--- a/tests/test-server.sh
+++ b/tests/test-server.sh
@@ -12,7 +12,8 @@ set -euo pipefail
 BINARY="${1:-.build/release/SwiftLM}"
 PORT="${2:-15413}"
 HOST="127.0.0.1"
-MODEL="mlx-community/Qwen2.5-0.5B-Instruct-4bit"  # Smallest model for CI
+# Overridable so the same smoke test can cover more than one architecture in CI.
+MODEL="${SWIFTLM_TEST_MODEL:-mlx-community/Qwen2.5-0.5B-Instruct-4bit}"  # Smallest model for CI
 URL="http://${HOST}:${PORT}"
 PASS=0
 FAIL=0


### PR DESCRIPTION
Two changes. The second exists because, while verifying the first, I found that gating alone would **not** have prevented the last bad release.

## 1. Releases now wait for CI

`release.yml` triggered directly on `push`, so it built and published **concurrently** with `CI Pipeline` and did not depend on it — a red pipeline still shipped a binary. Just merging #125 demonstrated it: the release finished and published while `main`'s CI was still `queued`.

- Trigger is now `workflow_run` on `CI Pipeline` → `completed`, with the job guarded on `conclusion == 'success'`.
- Checkout pins `workflow_run.head_sha`, so the release builds exactly the commit CI validated rather than a branch tip that may already have moved on.
- `workflow_run` carries no path filter, so the old `paths:` list is reimplemented as an explicit diff against the previous release tag — a docs-only commit no longer publishes. **Submodule pointer moves count as source**: the Gemma 4 fix reached users through a bump with no `.swift` diff at all, so omitting that would have silently stopped shipping submodule fixes.
- Manual `workflow_dispatch` is unchanged and still bypasses the gate.

One property worth knowing: `CI Pipeline` concludes `success` when only the `opencode` job fails, since that job is `continue-on-error`. Verified against `32987d8` — opencode failed, workflow concluded success. So the known runner OOM does not block releases.

## 2. The gate would not have caught b674 — so this adds the coverage that does

I replayed the gate against real history before claiming it worked:

| commit | CI conclusion | would gate have blocked? |
|---|---|---|
| `32987d8` (built b674) | **success** | **no** |
| `8aad37d` | failure | yes |

b674 shipped a Gemma 4 regression while CI was green, because **no job loads `gemma-4-e2b-it-4bit`**. That checkpoint ships `k_proj`/`v_proj` for its KV-shared layers while `e4b` omits them, so a change validated against e4b broke e2b entirely and nothing noticed.

So `tests/test-server.sh` now takes its model from `SWIFTLM_TEST_MODEL`, and the matrix gains a second `server` entry running the same 74-assertion smoke test against e2b. Cache keys are per-entry so the two `server` jobs don't collide.

## Verification

- **74/74 pass** against e2b locally with the fix in place.
- **Verified red**: reverting the fix makes the job fail immediately with the production error — `Unable to set language_model.model.layers.15.self_attn.v_proj … none not compatible with […]`.
- Source-change detector dry-run: swift-only → release, submodule-only → release, workflow → release, mixed → release, docs-only → skip, ci-only → skip. Replayed against four real commits.

## Caveat on this PR's own CI

Because the trigger changes, this PR's release behaviour cannot be fully exercised until it is on `main` — `workflow_run` fires from the version of the workflow on the default branch. The first merge after this lands is the real test, and `workflow_dispatch` remains as the escape hatch if anything misbehaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)