### PR TITLE
test: make the local suite actually runnable (1 test → 245)

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,24 @@ For a detailed breakdown on repository architecture, upstream synchronization, o
 
 ## 💻 Benchmarks & Testing
 
+### Unit tests
+
+MLX aborts the process when it cannot find its Metal library, so a bare `swift test`
+dies on the first test that touches MLX — leaving almost the whole suite unrun while the
+output still looks like a short, passing run. Install the metallib once after building
+the test bundle:
+
+```bash
+swift build --build-tests
+scripts/install-test-metallib.sh
+swift test
+```
+
+That takes the local run from 1 executed test to ~245. CI does the same step inline, so
+it is unaffected. A single suite can be run with `swift test --filter <SuiteName>`.
+
+### Benchmarks
+
 Run our automated benchmark suites via the interactive script:
 ```bash
 ./run_benchmark.sh

--- a/scripts/install-test-metallib.sh
+++ b/scripts/install-test-metallib.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# install-test-metallib.sh — put mlx.metallib where the test bundles can find it.
+#
+# MLX aborts the process when it cannot load its Metal library, so without this a bare
+# `swift test` dies on the first test that touches MLX — in practice the second test of
+# the run, leaving ~250 tests unexecuted while the output still looks like a normal
+# (short) pass. CI does this inline; this script is the same step for local use.
+#
+# Usage: scripts/install-test-metallib.sh [debug|release]   (default: both, if present)
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+CONFIGS=("${1:-debug release}")
+
+find_metallib() {
+    # 1. Already built by build.sh
+    for candidate in .build/*/release/mlx.metallib .build/*/release/default.metallib default.metallib; do
+        [ -f "$candidate" ] && { echo "$candidate"; return 0; }
+    done
+    # 2. From the mlx Python wheel, as CI does
+    local venv="${TMPDIR:-/tmp}/swiftlm_mlx_venv"
+    if [ ! -f "$venv"/lib/python*/site-packages/mlx/lib/mlx.metallib ]; then
+        echo "Fetching mlx.metallib from the mlx wheel…" >&2
+        python3 -m venv "$venv" >&2
+        "$venv/bin/pip" install --quiet mlx >&2
+    fi
+    ls "$venv"/lib/python*/site-packages/mlx/lib/mlx.metallib 2>/dev/null | head -1
+}
+
+METALLIB="$(find_metallib)"
+[ -n "$METALLIB" ] && [ -f "$METALLIB" ] || { echo "error: could not obtain mlx.metallib" >&2; exit 1; }
+echo "Using $METALLIB"
+
+INSTALLED=0
+# Next to the built products, and inside every .xctest bundle — MLX looks for a metallib
+# colocated with the running binary, which for tests is inside the bundle.
+while IFS= read -r dir; do
+    cp "$METALLIB" "$dir/mlx.metallib"
+    cp "$METALLIB" "$dir/default.metallib"
+    INSTALLED=$((INSTALLED + 1))
+done < <(
+    { for c in $CONFIGS; do ls -d .build/*/"$c" .build/"$c" 2>/dev/null; done
+      find .build -type d -name "MacOS" 2>/dev/null; } | sort -u
+)
+
+echo "Installed into $INSTALLED location(s)."
+[ "$INSTALLED" -gt 0 ] || { echo "error: no build directories found — run 'swift build --build-tests' first" >&2; exit 1; }


### PR DESCRIPTION
Tier 3 from #128.

## The trap

MLX aborts the process when it cannot load its Metal library. A bare `swift test` therefore dies on the first test that touches MLX — in practice the **second test of the run**:

```
Test Case '-[SwiftBuddyTests.AudioExtractionTests testAudio_Base64WAVExtraction]' passed
Test Case '-[SwiftBuddyTests.AudioExtractionTests testAudio_LongAudioChunking]' started.
MLX error: Failed to load the default metallib. library not found …
```

Everything after that goes unexecuted, and the output still reads as a short, passing run. A contributor can run the tests, see green, and have exercised **one assertion out of ~250**.

CI is unaffected — it installs the metallib inline (`ci.yml`, "Install MLX Metal library"), which is exactly why this went unnoticed.

## The fix

`scripts/install-test-metallib.sh` performs that same step locally. It prefers a metallib already produced by `build.sh`, otherwise pulls one from the `mlx` wheel as CI does, then installs it beside the built products **and inside every `.xctest` bundle** — MLX looks for a metallib colocated with the running binary, which for tests is inside the bundle, not next to it.

```bash
swift build --build-tests
scripts/install-test-metallib.sh
swift test
```

## Measured

| | Executed tests | Failures |
|---|---|---|
| before | **1** | 0 |
| after | **245** | 0 |

README documents the sequence in the Testing section.

## Note

This also means the "full suite green" claims made while fixing #108/#110/#112 were per-suite (`--filter`) runs, not a single invocation — the single invocation was never possible. It is now, and it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)