### PR TITLE
fix: withhold ambiguous tail so split stop sequences cannot leak (#126)

### DIFF
--- a/Sources/SwiftLM/Server.swift
+++ b/Sources/SwiftLM/Server.swift
@@ -1915,9 +1915,13 @@ func handleChatStreaming(
         var stopped = false
         var firstToken = true
         var tracker = ThinkingStateTracker(startInThinking: enableThinking && thinkingPreOpened)
-        // Raw characters already released downstream, and the tail withheld because it
-        // could still open a stop sequence. Counting what was actually emitted is what
-        // makes the stop path's remainder correct regardless of chunk boundaries.
+        // Raw characters handed to the thinking tracker — not necessarily characters on
+        // the wire, since the tracker may still be holding a partial tag — plus the tail
+        // withheld because it could still open a stop sequence. Counting consumption
+        // rather than chunk offsets is what makes the stop remainder correct regardless
+        // of where chunk boundaries fall. The count is in grapheme clusters, so the
+        // min() clamp at the stop path guards the rare case where a combining mark
+        // arriving in a later chunk merges with the previous one.
         var emittedTextCount = 0
         var heldStopTail = ""
         // Unconditional cleanup: guarantees heartbeat is cancelled on ALL exit paths
@@ -1987,6 +1991,11 @@ func handleChatStreaming(
                                 finishReason: nil
                             ))
                         }
+                        // Everything accumulated so far has now gone to the client, so
+                        // the stop path must not re-emit it. Counting raw characters
+                        // consumed (not the cleaned derivative that went on the wire)
+                        // keeps this consistent with how the normal path counts.
+                        emittedTextCount = fullText.count
                         jsonBuffering = false
                     }
                     continue  // skip normal emit while buffering or just flushed
@@ -2138,6 +2147,17 @@ func handleChatStreaming(
                         fflush(stdout)
                     }
                 }
+            }
+        }
+        // Safety net: the tail is normally released in `case .info`, but a stream that
+        // ends without one — a generation error, or cancellation mid-decode — would
+        // otherwise discard up to maxStopLength-1 characters of real output.
+        if !stopped && !heldStopTail.isEmpty {
+            let (r, c) = enableThinking ? tracker.process(heldStopTail) : ("", heldStopTail)
+            heldStopTail = ""
+            if !r.isEmpty || !c.isEmpty {
+                cont.yield(sseChunk(modelId: modelId, reasoningContent: r.isEmpty ? nil : r,
+                                    content: c.isEmpty ? nil : c, finishReason: nil))
             }
         }
         cont.finish()

--- a/Sources/SwiftLM/Server.swift
+++ b/Sources/SwiftLM/Server.swift
@@ -1915,6 +1915,11 @@ func handleChatStreaming(
         var stopped = false
         var firstToken = true
         var tracker = ThinkingStateTracker(startInThinking: enableThinking && thinkingPreOpened)
+        // Raw characters already released downstream, and the tail withheld because it
+        // could still open a stop sequence. Counting what was actually emitted is what
+        // makes the stop path's remainder correct regardless of chunk boundaries.
+        var emittedTextCount = 0
+        var heldStopTail = ""
         // Unconditional cleanup: guarantees heartbeat is cancelled on ALL exit paths
         // (normal completion, client disconnect, or task cancellation during prefill).
         defer {
@@ -1995,14 +2000,24 @@ func handleChatStreaming(
                 // anything after it — review finding on #115. The pre-review code had
                 // the opposite bug: its arithmetic assumed everything before this chunk
                 // was already emitted, dropping text the tracker was holding.)
+                //
+                // A stop sequence can also straddle two chunks, in which case this chunk
+                // shows no match and its tail is the opening of one. Emitting that tail
+                // hands the client the very text it asked to be cut (#126), so the
+                // ambiguous suffix is withheld until the next chunk resolves it.
                 let stopHit = checkStopSequences(fullText, stopSequences: stopSequences)
-                let survivingText: String
+                var survivingText: String
                 if let (trimmedFull, _) = stopHit {
-                    let priorCount = fullText.count - text.count
-                    survivingText = String(text.prefix(max(0, trimmedFull.count - priorCount)))
+                    // The stop completed. Everything the client is owed is the part of
+                    // fullText before it, minus what has already gone out.
+                    survivingText = String(trimmedFull.dropFirst(min(emittedTextCount, trimmedFull.count)))
                 } else {
-                    survivingText = text
+                    let candidate = heldStopTail + text
+                    let holdLength = pendingStopPrefixLength(candidate, stopSequences: stopSequences)
+                    survivingText = String(candidate.dropLast(holdLength))
+                    heldStopTail = String(candidate.suffix(holdLength))
                 }
+                emittedTextCount += survivingText.count
 
                 // ── Route text through thinking state machine ──
                 let (reasoningText, contentText) = enableThinking
@@ -2066,6 +2081,17 @@ func handleChatStreaming(
                         reason = "length"
                     case .cancelled, .stop:
                         reason = hasToolCalls ? "tool_calls" : "stop"
+                    }
+                    // The withheld tail never became a stop sequence, so it is ordinary
+                    // output and must not be dropped.
+                    if !heldStopTail.isEmpty {
+                        let (r, c) = enableThinking
+                            ? tracker.process(heldStopTail) : ("", heldStopTail)
+                        heldStopTail = ""
+                        if !r.isEmpty || !c.isEmpty {
+                            cont.yield(sseChunk(modelId: modelId, reasoningContent: r.isEmpty ? nil : r,
+                                                content: c.isEmpty ? nil : c, finishReason: nil))
+                        }
                     }
                     // Drain text the tracker was holding on a partial tag that never
                     // completed, otherwise the tail of the response is dropped (#108).
@@ -2636,6 +2662,33 @@ struct ApiKeyMiddleware<Context: RequestContext>: RouterMiddleware {
 }
 
 // ── Stop Sequence Detection ──────────────────────────────────────────────────
+
+/// How many trailing characters of `text` must be withheld because they could still turn
+/// out to be the opening of a stop sequence.
+///
+/// The stop check only ever fires on the chunk that *completes* a stop sequence, so a
+/// stop split across two chunks had its first part streamed before the match was visible:
+/// `stop: ["\nUser:"]` arriving as `"\nUser"` then `":"` sent `"\nUser"` to the client —
+/// the exact text the client asked to be cut (#126). Withholding the ambiguous tail until
+/// the next chunk resolves it closes that window, at the cost of one chunk of latency on
+/// the tail. This mirrors ThinkingStateTracker's partial-tag handling.
+///
+/// Returns 0 when nothing is ambiguous, so the common case emits immediately.
+func pendingStopPrefixLength(_ text: String, stopSequences: [String]) -> Int {
+    var longest = 0
+    for stop in stopSequences where !stop.isEmpty {
+        // Only *proper* prefixes matter: a complete match is the stop check's job.
+        let maxLength = min(text.count, stop.count - 1)
+        guard maxLength > 0 else { continue }
+        for length in stride(from: maxLength, through: 1, by: -1) where length > longest {
+            if text.hasSuffix(String(stop.prefix(length))) {
+                longest = length
+                break
+            }
+        }
+    }
+    return longest
+}
 
 /// Trims `text` at the earliest stop sequence it contains.
 ///

--- a/tests/SwiftLMTests/StopHoldbackTests.swift
+++ b/tests/SwiftLMTests/StopHoldbackTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+import Foundation
+@testable import SwiftLM
+
+// MARK: - Regression tests for Issue #126 — stop sequences split across chunks
+//
+// The stop check only fires on the chunk that completes a stop sequence, so a stop split
+// across two chunks had its first part streamed before the match was visible. These pin
+// the withholding rule that closes that window.
+final class StopHoldbackTests: XCTestCase {
+
+    private let stops = ["\nUser:", "<|im_end|>"]
+
+    func testNothingHeldWhenTailIsUnambiguous() {
+        XCTAssertEqual(pendingStopPrefixLength("a normal answer.", stopSequences: stops), 0)
+        XCTAssertEqual(pendingStopPrefixLength("", stopSequences: stops), 0)
+    }
+
+    /// The whole point: a partial stop at the tail must be withheld.
+    func testHoldsPartialStopAtTheTail() {
+        XCTAssertEqual(pendingStopPrefixLength("done.\nUser", stopSequences: stops), 5)
+        XCTAssertEqual(pendingStopPrefixLength("answer<|im_", stopSequences: stops), 5)
+        XCTAssertEqual(pendingStopPrefixLength("answer<", stopSequences: stops), 1)
+    }
+
+    /// A complete stop is the stop check's job, not the holdback's — withholding it here
+    /// would double-handle it.
+    func testCompleteStopIsNotHeld() {
+        XCTAssertEqual(pendingStopPrefixLength("done.\nUser:", stopSequences: stops), 0)
+        XCTAssertEqual(pendingStopPrefixLength("answer<|im_end|>", stopSequences: stops), 0)
+    }
+
+    /// With several stops sharing a prefix, the longest ambiguity wins.
+    func testLongestAmbiguityWins() {
+        let overlapping = ["<|end|>", "<|endoftext|>"]
+        XCTAssertEqual(pendingStopPrefixLength("x<|end", stopSequences: overlapping), 5)
+        // "<|end|" cannot complete "<|end|>"… it can: it is a proper prefix of length 6.
+        XCTAssertEqual(pendingStopPrefixLength("x<|end|", stopSequences: overlapping), 6)
+    }
+
+    func testEmptyAndAbsentStopsAreIgnored() {
+        XCTAssertEqual(pendingStopPrefixLength("anything", stopSequences: []), 0)
+        XCTAssertEqual(pendingStopPrefixLength("anything", stopSequences: [""]), 0)
+    }
+
+    /// Multi-byte content must not be split mid-character; the count is in characters.
+    func testUnicodeTailIsCountedInCharacters() {
+        XCTAssertEqual(pendingStopPrefixLength("東京です", stopSequences: stops), 0)
+        XCTAssertEqual(pendingStopPrefixLength("東京です\nUser", stopSequences: stops), 5)
+    }
+
+    /// End-to-end shape: feeding a stop one character at a time must never emit any
+    /// prefix of it, and must emit everything before it exactly once.
+    func testStreamSimulationNeverEmitsAStopPrefix() {
+        let full = "The answer is 42.\nUser: next question"
+        var emitted = ""
+        var pending = ""
+        var stopped = false
+
+        for character in full {
+            guard !stopped else { break }
+            pending += String(character)
+            if let (trimmed, _) = checkStopSequences(pending, stopSequences: stops) {
+                emitted += trimmed
+                stopped = true
+                break
+            }
+            let hold = pendingStopPrefixLength(pending, stopSequences: stops)
+            let safe = pending.count - hold
+            if safe > 0 {
+                emitted += String(pending.prefix(safe))
+                pending = String(pending.dropFirst(safe))
+            }
+        }
+
+        XCTAssertEqual(emitted, "The answer is 42.", "everything before the stop, and nothing after")
+        XCTAssertFalse(emitted.contains("\nUser"), "no prefix of the stop sequence may be emitted")
+        XCTAssertTrue(stopped)
+    }
+}

--- a/tests/SwiftLMTests/StopHoldbackTests.swift
+++ b/tests/SwiftLMTests/StopHoldbackTests.swift
@@ -34,7 +34,7 @@ final class StopHoldbackTests: XCTestCase {
     func testLongestAmbiguityWins() {
         let overlapping = ["<|end|>", "<|endoftext|>"]
         XCTAssertEqual(pendingStopPrefixLength("x<|end", stopSequences: overlapping), 5)
-        // "<|end|" cannot complete "<|end|>"… it can: it is a proper prefix of length 6.
+        // "<|end|" is a proper prefix of "<|end|>" (length 6), so it is still ambiguous.
         XCTAssertEqual(pendingStopPrefixLength("x<|end|", stopSequences: overlapping), 6)
     }
 
@@ -43,9 +43,15 @@ final class StopHoldbackTests: XCTestCase {
         XCTAssertEqual(pendingStopPrefixLength("anything", stopSequences: [""]), 0)
     }
 
-    /// Multi-byte content must not be split mid-character; the count is in characters.
-    func testUnicodeTailIsCountedInCharacters() {
-        XCTAssertEqual(pendingStopPrefixLength("東京です", stopSequences: stops), 0)
+    /// The count is in grapheme clusters, so a multi-scalar cluster counts as one and is
+    /// never split. The earlier version of this test used only multi-*byte* characters,
+    /// each of which is a single scalar — it could not have caught a scalar/cluster mixup.
+    func testCountIsInGraphemeClustersNotScalars() {
+        let family = "👨‍👩‍👧"  // one cluster, several scalars joined by ZWJ
+        XCTAssertEqual(family.count, 1, "precondition: the fixture is a single cluster")
+        XCTAssertEqual(pendingStopPrefixLength(family, stopSequences: stops), 0)
+        XCTAssertEqual(pendingStopPrefixLength(family + "\nUser", stopSequences: stops), 5,
+                       "the held tail is measured in clusters, unaffected by the emoji's scalars")
         XCTAssertEqual(pendingStopPrefixLength("東京です\nUser", stopSequences: stops), 5)
     }
 

--- a/tests/test-contract.sh
+++ b/tests/test-contract.sh
@@ -92,10 +92,14 @@ for line in sys.stdin:
     for ch in d.get("choices",[]):
         out += ch.get("delta",{}).get("content") or ""
 print(out)')
+# Absence alone would also pass if the fix over-withheld and dropped the tail, so assert
+# the expected prefix actually arrived too.
 if echo "$STRADDLE" | grep -q "own"; then
     fail "a prefix of the stop sequence leaked: $(echo "$STRADDLE" | head -c 60)"
+elif ! echo "$STRADDLE" | grep -q "The quick br"; then
+    fail "text before the stop was dropped — got: $(echo "$STRADDLE" | head -c 60)"
 else
-    pass "no prefix of a token-straddling stop sequence reached the client"
+    pass "token-straddling stop: prefix withheld, preceding text delivered"
 fi
 
 # ── 3. Reasoning must not leak into content ──────────────────────────────────

--- a/tests/test-contract.sh
+++ b/tests/test-contract.sh
@@ -74,6 +74,30 @@ else
     pass "stop sequence absent from assembled stream"
 fi
 
+# ── 2b. A stop sequence that cannot be a single token ────────────────────────
+# "own fox" spans a token boundary by construction, so this exercises the straddling
+# path specifically: before #126 was fixed, the client received "The quick brown".
+log "Test 2b: stop sequence spanning a token boundary is not leaked"
+PROMPT="Repeat this exactly: The quick brown fox jumps over the lazy dog"
+STRADDLE=$(curl -sf -N "$URL/v1/chat/completions" -H 'Content-Type: application/json' \
+    -d "{\"model\":\"x\",\"messages\":[{\"role\":\"user\",\"content\":\"$PROMPT\"}],\"max_tokens\":40,\"temperature\":0,\"stream\":true,\"stop\":[\"own fox\"]}" \
+    | python3 -c '
+import json,sys
+out=""
+for line in sys.stdin:
+    line=line.strip()
+    if not line.startswith("data: ") or line=="data: [DONE]": continue
+    try: d=json.loads(line[6:])
+    except Exception: continue
+    for ch in d.get("choices",[]):
+        out += ch.get("delta",{}).get("content") or ""
+print(out)')
+if echo "$STRADDLE" | grep -q "own"; then
+    fail "a prefix of the stop sequence leaked: $(echo "$STRADDLE" | head -c 60)"
+else
+    pass "no prefix of a token-straddling stop sequence reached the client"
+fi
+
 # ── 3. Reasoning must not leak into content ──────────────────────────────────
 # Issue #108: a template that pre-opens <think> left the whole reasoning block in
 # `content`, with a stray closing tag inside it.


### PR DESCRIPTION
Fixes #126.

## Reproduced first

The stop check only fires on the chunk that *completes* a stop sequence, so one split across two chunks has its first part streamed before the match is visible. Against a live server, with `stop: ["own fox"]` — a string that cannot be a single token, so it must straddle chunks:

| | streamed to client |
|---|---|
| before | `'The quick brown'` ← leaks `own` |
| after | `'The quick br'` |

## The fix

`pendingStopPrefixLength(_:stopSequences:)` reports how many trailing characters could still be the opening of a stop sequence. The streaming loop withholds exactly that many, releasing them when the next chunk resolves the ambiguity — or at end of generation, when they turn out to be ordinary text. Same technique `ThinkingStateTracker` already uses for partial tags. Costs one chunk of latency on the tail, nothing when the tail is unambiguous.

It also replaces the stop path's remainder arithmetic. That computation has now been wrong in **both** directions — first dropping text the tracker was holding, then leaking the stop sequence — because it assumed a relationship between chunk boundaries and what had been emitted that the tracker breaks. It now uses a running count of characters actually released, which does not depend on chunk boundaries at all.

## Verification

- **Verified red**: reverting the holdback restores the leak, live.
- Three stop shapes checked against predictable output: `brown` → `'The quick '`, `own fox` → `'The quick br'`, `lazy` → `'The quick brown fox jumps over the '`.
- The straddling case is added to `tests/test-contract.sh`, so CI guards it rather than my laptop: **7 passed, 0 failed, 2 skipped**.
- 7 new unit tests for the helper, including a character-by-character stream simulation asserting no stop prefix is ever emitted.
- Full suite: **259 tests, 0 failures**.

## Note on my first attempt at this area

My initial live test used a prompt whose output was digits, so none of the stop strings appeared and all three "passed" vacuously. The results above come from a prompt with predictable output that actually contains the stop.

Given this is the streaming hot path and two previous changes here each introduced a defect that review caught, I would rather this had a review pass than be merged on green CI alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)