### PR TITLE
fix: apply the stop holdback to /v1/completions too (#133)

### DIFF
--- a/Sources/SwiftLM/Server.swift
+++ b/Sources/SwiftLM/Server.swift
@@ -2429,6 +2429,10 @@ func handleTextStreaming(
         var fullText = ""
         var stopped = false
         var firstToken = true
+        // Characters already sent, and the tail withheld because it could still open
+        // a stop sequence (#133). Local to this loop; the chat path has its own pair.
+        var emittedTextCount = 0
+        var heldStopTail = ""
         // Unconditional cleanup: guarantees heartbeat is cancelled on ALL exit paths
         // (normal completion, client disconnect, or task cancellation during prefill).
         defer {
@@ -2453,18 +2457,31 @@ func handleTextStreaming(
                 if completionTokenCount % 8 == 0 {
                     try? await Task.sleep(for: .microseconds(50))
                 }
+                // Same treatment as the chat path (#126, #133): a stop sequence spanning
+                // two chunks shows no match on the first, and emitting that chunk hands
+                // the client the very text it asked to be cut. Withhold the ambiguous
+                // tail, and track characters actually released rather than deriving a
+                // position from chunk boundaries — that arithmetic was wrong in both
+                // directions on the chat path before it was replaced.
                 if let (trimmedText, _) = checkStopSequences(fullText, stopSequences: stopSequences) {
-                    let emittedSoFar = fullText.count - text.count
-                    if trimmedText.count > emittedSoFar {
-                        let partialText = String(trimmedText.suffix(trimmedText.count - emittedSoFar))
-                        cont.yield(sseTextChunk(modelId: modelId, text: partialText, finishReason: nil))
+                    let remainder = String(
+                        trimmedText.dropFirst(min(emittedTextCount, trimmedText.count)))
+                    if !remainder.isEmpty {
+                        cont.yield(sseTextChunk(modelId: modelId, text: remainder, finishReason: nil))
                     }
                     cont.yield(sseTextChunk(modelId: modelId, text: "", finishReason: "stop"))
                     cont.yield("data: [DONE]\n\n")
                     cont.finish()
                     stopped = true
                 } else {
-                    cont.yield(sseTextChunk(modelId: modelId, text: text, finishReason: nil))
+                    let candidate = heldStopTail + text
+                    let holdLength = pendingStopPrefixLength(candidate, stopSequences: stopSequences)
+                    let releasable = String(candidate.dropLast(holdLength))
+                    heldStopTail = String(candidate.suffix(holdLength))
+                    if !releasable.isEmpty {
+                        emittedTextCount += releasable.count
+                        cont.yield(sseTextChunk(modelId: modelId, text: releasable, finishReason: nil))
+                    }
                 }
             case .toolCall:
                 break
@@ -2481,11 +2498,21 @@ func handleTextStreaming(
                     case .cancelled, .stop:
                         reason = "stop"
                     }
+                    if !heldStopTail.isEmpty {
+                        cont.yield(sseTextChunk(modelId: modelId, text: heldStopTail, finishReason: nil))
+                        heldStopTail = ""
+                    }
                     cont.yield(sseTextChunk(modelId: modelId, text: "", finishReason: reason))
                     cont.yield("data: [DONE]\n\n")
                     cont.finish()
                 }
             }
+        }
+        // The tail never became a stop sequence, so it is ordinary output. Normally
+        // released above; this covers a stream that ends without an .info event.
+        if !stopped && !heldStopTail.isEmpty {
+            cont.yield(sseTextChunk(modelId: modelId, text: heldStopTail, finishReason: nil))
+            heldStopTail = ""
         }
         cont.finish()
         let duration = Date().timeIntervalSince(genStart)

--- a/tests/test-contract.sh
+++ b/tests/test-contract.sh
@@ -102,6 +102,29 @@ else
     pass "token-straddling stop: prefix withheld, preceding text delivered"
 fi
 
+# ── 2c. Same guarantee on the legacy /v1/completions endpoint ────────────────
+log "Test 2c: /v1/completions does not leak a token-straddling stop sequence"
+COMPLETION=$(curl -sf -N "$URL/v1/completions" -H 'Content-Type: application/json' \
+    -d '{"model":"x","prompt":"Repeat exactly: The quick brown fox jumps over the lazy dog\n","max_tokens":40,"temperature":0,"stream":true,"stop":["own fox"]}' \
+    | python3 -c '
+import json,sys
+out=""
+for line in sys.stdin:
+    line=line.strip()
+    if not line.startswith("data: ") or line=="data: [DONE]": continue
+    try: d=json.loads(line[6:])
+    except Exception: continue
+    for ch in d.get("choices",[]):
+        out += ch.get("text") or ""
+print(out)')
+if echo "$COMPLETION" | grep -q "own"; then
+    fail "/v1/completions leaked a stop prefix: $(echo "$COMPLETION" | head -c 60)"
+elif ! echo "$COMPLETION" | grep -q "The quick br"; then
+    fail "/v1/completions dropped text before the stop: $(echo "$COMPLETION" | head -c 60)"
+else
+    pass "/v1/completions withholds the prefix and delivers preceding text"
+fi
+
 # ── 3. Reasoning must not leak into content ──────────────────────────────────
 # Issue #108: a template that pre-opens <think> left the whole reasoning block in
 # `content`, with a stray closing tag inside it.


### PR DESCRIPTION
Fixes #133. #132 fixed `/v1/chat/completions`; this is the same defect on the legacy text endpoint, which that PR explicitly left out of scope.

## Reproduced

Stop `"own fox"` — which cannot be a single token, so it necessarily straddles chunks:

| | streamed to client |
|---|---|
| before | `'The quick brown'` ← leaks `own` |
| after | `'The quick br'` |

Verified red: reverting the holdback restores the leak.

## Change

Same approach as #132 — withhold the tail that could still open a stop sequence via the existing `pendingStopPrefixLength`, release it when the next chunk resolves the ambiguity, on normal completion, or via a post-loop safety net if the stream ends without an `.info` event. The stop remainder now comes from characters actually released rather than `fullText.count - text.count`, which was wrong in both directions on the chat path before being replaced.

This path has no thinking tracker, so it is the simpler of the two: released text goes straight to the wire, and `emittedTextCount` is exactly what the client received.

## Coverage

`tests/test-contract.sh` gains the `/v1/completions` case, so CI now guards both endpoints: **8 passed, 0 failed, 2 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)