### PR TITLE
fix: SwiftBuddy app version permanently stuck at 1.0 (build 1)

### DIFF
--- a/.github/workflows/build-dmg.yml
+++ b/.github/workflows/build-dmg.yml
@@ -18,9 +18,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-depth: 0  # Full history — needed for `git rev-list --count HEAD` (build number)
 
       - name: Generate Xcode Project
         run: |
+          # See generate_xcodeproj.py's header comment: without these, every
+          # build reports the same hardcoded 1.0/1 app version. Matches
+          # release.yml's scheme so ad-hoc and release builds are consistent.
+          export SWIFTBUDDY_MARKETING_VERSION="$(date -u +%Y.%m.%d)"
+          export SWIFTBUDDY_BUILD_NUMBER="$(git rev-list --count HEAD)"
           cd SwiftBuddy && python3 generate_xcodeproj.py
 
       - name: Build Ad-Hoc App

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,6 +140,17 @@ jobs:
           
       - name: Build macOS DMG Wrapper
         run: |
+          # Previously hardcoded 1.0/1 inside generate_xcodeproj.py, so every
+          # release ever built reported the same app version regardless of
+          # which commit produced it. SWIFTBUDDY_BUILD_NUMBER reuses the same
+          # `git rev-list --count HEAD` counter this workflow's bNNN release
+          # tags already use (step "Determine tag name" above), so the app's
+          # build number and its release tag always agree. Marketing version
+          # is date-based (always distinct, no manual "when do we bump this"
+          # decision needed for a pipeline that releases roughly daily).
+          export SWIFTBUDDY_MARKETING_VERSION="$(date -u +%Y.%m.%d)"
+          export SWIFTBUDDY_BUILD_NUMBER="$(git rev-list --count HEAD)"
+          echo "App version: ${SWIFTBUDDY_MARKETING_VERSION} (${SWIFTBUDDY_BUILD_NUMBER})"
           cd SwiftBuddy && python3 generate_xcodeproj.py
           cd ..
           xcodebuild clean build \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,7 +198,7 @@ jobs:
           ### Download
 
           - **CLI Server**: [macOS Apple Silicon (arm64)](https://github.com/SharpAI/SwiftLM/releases/download/${{ steps.tag.outputs.name }}/SwiftLM-${{ steps.tag.outputs.name }}-macos-arm64.tar.gz)
-          - **GUI Desktop App**: Download the attached `SwiftBuddy-macOS.dmg` below!
+          - **GUI Desktop App**: Download the attached DMG file below!
 
           ### Quick Start
           

--- a/SwiftBuddy/generate_xcodeproj.py
+++ b/SwiftBuddy/generate_xcodeproj.py
@@ -4,6 +4,20 @@ generate_xcodeproj.py — Generates SwiftBuddy.xcodeproj without xcodegen.
 Includes MLXInferenceCore sources directly + local SPM packages (mlx-swift, mlx-swift-lm).
 Run from the SwiftBuddy/ directory:
     python3 generate_xcodeproj.py
+
+Since this script (not a checked-in Info.plist) regenerates project.pbxproj
+fresh on every build, it's also the single place that controls the app's
+displayed version — MARKETING_VERSION (CFBundleShortVersionString) and
+CURRENT_PROJECT_VERSION (CFBundleVersion) were previously hardcoded to
+"1.0"/"1" here, so every release ever built reported the same version
+regardless of which commit or CI run produced it. Override either via env
+var; both default to the previous hardcoded values for local/manual runs
+where CI hasn't set them:
+    SWIFTBUDDY_MARKETING_VERSION   e.g. "2026.08.27" (release.yml sets this
+                                    to the build date — see that workflow)
+    SWIFTBUDDY_BUILD_NUMBER        e.g. "703" (release.yml sets this to
+                                    `git rev-list --count HEAD`, the same
+                                    counter its bNNN release tags use)
 """
 
 import os, uuid
@@ -11,6 +25,9 @@ from pathlib import Path
 
 def uid():
     return uuid.uuid4().hex[:24].upper()
+
+MARKETING_VERSION = os.environ.get("SWIFTBUDDY_MARKETING_VERSION", "1.0")
+BUILD_NUMBER = os.environ.get("SWIFTBUDDY_BUILD_NUMBER", "1")
 
 # ── UUIDs ─────────────────────────────────────────────────────────────
 PROJ          = uid()
@@ -343,7 +360,7 @@ def pbxproj():
 \t\t\t\tASSTCATALOG_COMPILER_APPICON_NAME = AppIcon;
 \t\t\t\tASSTCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 \t\t\t\tCODE_SIGN_STYLE = Automatic;
-\t\t\t\tCURRENT_PROJECT_VERSION = 1;
+\t\t\t\tCURRENT_PROJECT_VERSION = {BUILD_NUMBER};
 \t\t\t\tGENERATE_INFOPLIST_FILE = YES;
 \t\t\t\tINFOPLIST_KEY_CFBundleDisplayName = "SwiftBuddy Chat";
 \t\t\t\tINFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 SharpAI";
@@ -354,7 +371,7 @@ def pbxproj():
 \t\t\t\tINFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 \t\t\t\tIPHONEOS_DEPLOYMENT_TARGET = 17.0;
 \t\t\t\tMACOS_DEPLOYMENT_TARGET = 14.0;
-\t\t\t\tMARKETING_VERSION = 1.0;
+\t\t\t\tMARKETING_VERSION = {MARKETING_VERSION};
 \t\t\t\tPRODUCT_BUNDLE_IDENTIFIER = com.sharpai.SwiftBuddy;
 \t\t\t\tPRODUCT_NAME = "$(TARGET_NAME)";
 \t\t\t\tSDKROOT = auto;
@@ -371,12 +388,12 @@ def pbxproj():
 \t\t\t\tASSTCATALOG_COMPILER_APPICON_NAME = AppIcon;
 \t\t\t\tASSTCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 \t\t\t\tCODE_SIGN_STYLE = Automatic;
-\t\t\t\tCURRENT_PROJECT_VERSION = 1;
+\t\t\t\tCURRENT_PROJECT_VERSION = {BUILD_NUMBER};
 \t\t\t\tGENERATE_INFOPLIST_FILE = YES;
 \t\t\t\tINFOPLIST_KEY_CFBundleDisplayName = "SwiftBuddy Chat";
 \t\t\t\tIPHONEOS_DEPLOYMENT_TARGET = 17.0;
 \t\t\t\tMACOS_DEPLOYMENT_TARGET = 14.0;
-\t\t\t\tMARKETING_VERSION = 1.0;
+\t\t\t\tMARKETING_VERSION = {MARKETING_VERSION};
 \t\t\t\tPRODUCT_BUNDLE_IDENTIFIER = com.sharpai.SwiftBuddy;
 \t\t\t\tPRODUCT_NAME = "$(TARGET_NAME)";
 \t\t\t\tSDKROOT = auto;


### PR DESCRIPTION
## Summary
The app's displayed version never changed across any release, ever. Root cause: `SwiftBuddy/generate_xcodeproj.py` regenerates `project.pbxproj` fresh on every build (it's gitignored, not a checked-in file), and `MARKETING_VERSION`/`CURRENT_PROJECT_VERSION` were hardcoded literals baked into its template. Neither `release.yml` (which releases roughly daily, tagged `bNNN` by commit count) nor `build-dmg.yml` ever touched them, so every DMG and app bundle ever built — regardless of which commit or release tag it came from — reported itself as "SwiftBuddy 1.0" build "1". `scripts/build_dmg.sh` already reads `CFBundleShortVersionString` from the built app for the DMG filename, so this silently named every DMG `SwiftBuddy-macOS-v1.0.dmg` too.

## Fix
- `generate_xcodeproj.py` now reads both values from env vars (`SWIFTBUDDY_MARKETING_VERSION`, `SWIFTBUDDY_BUILD_NUMBER`), defaulting to the previous hardcoded values when unset — local/manual `python3 generate_xcodeproj.py` runs are unaffected.
- `release.yml` and `build-dmg.yml` now set:
  - **build number** = `git rev-list --count HEAD`, the same counter `release.yml` already uses for its `bNNN` release tags, so the app's build number and its release tag always agree.
  - **marketing version** = build date (`YYYY.MM.DD`) — always distinct per day, no manual "when do we bump this" decision needed for a pipeline that releases close to daily.
- `build-dmg.yml`'s checkout gained `fetch-depth: 0` — it was a shallow clone, so `git rev-list --count HEAD` there would've returned ~1 regardless of actual history (`release.yml` already had this for the same reason).

## Verification
Ran `python3 generate_xcodeproj.py` locally:
- With no env vars set: reproduces the exact previous hardcoded output (`MARKETING_VERSION = 1.0`, `CURRENT_PROJECT_VERSION = 1`) — confirms no behavior change for local/manual runs.
- With `SWIFTBUDDY_MARKETING_VERSION=2026.08.27 SWIFTBUDDY_BUILD_NUMBER=703`: both values interpolate correctly into the generated `project.pbxproj`.
Both workflow YAML files validated with `yaml.safe_load`.

## Test plan
- [x] Local dry-run of `generate_xcodeproj.py` with and without env vars.
- [ ] CI green (this touches release infra — the actual release.yml run is the real end-to-end check).