### PR TITLE
fix: repair regressed mlx-swift submodule pin, wire up Gemma4MTPBench

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,8 @@ let package = Package(
         .library(name: "DFlash", targets: ["DFlash"]),
         .executable(name: "SwiftLM", targets: ["SwiftLM"]),
         .executable(name: "SwiftBuddy", targets: ["SwiftBuddy"]),
-        .executable(name: "DFlashKernelBench", targets: ["DFlashKernelBench"])
+        .executable(name: "DFlashKernelBench", targets: ["DFlashKernelBench"]),
+        .executable(name: "Gemma4MTPBench", targets: ["Gemma4MTPBench"])
     ],
     dependencies: [
         // Local Apple MLX Swift fork for C++ extensions
@@ -52,6 +53,18 @@ let package = Package(
                 .product(name: "MLXNN", package: "mlx-swift"),
             ],
             path: "Sources/DFlashKernelBench"
+        ),
+        // ── Gemma4 MTP Speculative Decoding Benchmark ───────────────
+        .executableTarget(
+            name: "Gemma4MTPBench",
+            dependencies: [
+                "MLXInferenceCore",
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXLLM", package: "mlx-swift-lm"),
+                .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ],
+            path: "Sources/Gemma4MTPBench"
         ),
         // ── STFT Audio Profiling Testing Script (macOS only) ───────────
         .executableTarget(

--- a/scripts/bootstrap_local_tests.sh
+++ b/scripts/bootstrap_local_tests.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Makes `swift test` runnable locally without CI's help.
+#
+# A bare `swift test` aborts with "Failed to load the default metallib"
+# because Package.swift links MLX but nothing on a local machine ever builds
+# or installs mlx.metallib. CI works around this in .github/workflows/ci.yml
+# ("Install MLX Metal library" step) by pip-installing the `mlx` wheel and
+# copying its bundled metallib into every built .xctest bundle. This script
+# does the same thing locally.
+set -eo pipefail
+
+VENV_DIR="${MLX_METALLIB_VENV:-/tmp/swiftlm_mlx_venv}"
+
+echo "=> Building test harness (swift build --build-tests)..."
+swift build --build-tests
+
+echo "=> Installing MLX Metal library..."
+if [ ! -d "$VENV_DIR" ]; then
+    python3 -m venv "$VENV_DIR"
+fi
+"$VENV_DIR/bin/pip" install --quiet --upgrade mlx
+
+METALLIB=$(find "$VENV_DIR" -name "mlx.metallib" | head -1)
+if [ -z "$METALLIB" ]; then
+    echo "error: mlx.metallib not found after pip install mlx" >&2
+    exit 1
+fi
+
+cp "$METALLIB" .build/debug/ 2>/dev/null || true
+cp "$METALLIB" .build/release/ 2>/dev/null || true
+find .build -type d -name "MacOS" -exec cp "$METALLIB" {}/ \;
+
+echo "=> Done. Run tests with: swift test --skip-build"


### PR DESCRIPTION
## Summary
- Bumps the `mlx-swift` submodule pin forward to its current `origin/main` tip (`5639a6d`). The previously pinned commit was actually an *ancestor* of the prior pin — a regression, not a bump — that was missing `MLXFast.fromFp8`, which `mlx-swift-lm`'s `FP8Linear.swift` now depends on.
- Wires the already-committed `Sources/Gemma4MTPBench` benchmark into `Package.swift` as an `executableTarget`. It depends on `DualModelMTP`/`MTPTokenIterator`/`Gemma4AssistantModel`, which only exist once `mlx-swift-lm` is past the DSA stage-2 merge (already the pin on `main`) — so it silently never built before.
- Adds `scripts/bootstrap_local_tests.sh`, which mirrors CI's "Install MLX Metal library" step (pip install `mlx`, copy its bundled `mlx.metallib` into every built `.xctest` bundle) so `swift test` is runnable locally without CI's help. This is the Tier 3 item from #128.

## Test plan
- [x] `swift build --build-tests` — clean build, 0 errors, in an isolated worktree against `origin/main`
- [x] `./scripts/bootstrap_local_tests.sh` then `swift test --skip-build --filter SwiftLMTests` — 161 tests, 0 failures
- [x] `swift test --skip-build --filter SwiftBuddyTests --disable-swift-testing` — 86 tests (9 skipped), 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)